### PR TITLE
Allow endian swapping signed integers

### DIFF
--- a/oxenc/endian.h
+++ b/oxenc/endian.h
@@ -49,13 +49,13 @@ namespace oxenc {
     /// True if this is a big-endian platform
     inline constexpr bool big_endian = !little_endian;
 
-    /// True if the type is unsigned and of a size we support swapping.  (We also allow size-1
+    /// True if the type is integral and of a size we support swapping.  (We also allow size-1
     /// values to be passed here for completeness, though nothing is ever swapped for such a value).
     template <typename T> constexpr bool is_endian_swappable =
-        std::is_unsigned_v<T> && (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
+        std::is_integral_v<T> && (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
 
-    /// Byte swaps an unsigned integer value unconditionally.  You usually want to use one of the
-    /// other endian-aware functions rather than this.
+    /// Byte swaps an integer value unconditionally.  You usually want to use one of the other
+    /// endian-aware functions rather than this.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void byteswap_inplace(T& val) {
         if constexpr (sizeof(T) == 2)
@@ -66,47 +66,47 @@ namespace oxenc {
             val = bswap_64(val);
     }
 
-    /// Converts a host-order unsigned integer value into a little-endian value, mutating it.  Does
-    /// nothing on little-endian platforms.
+    /// Converts a host-order integer value into a little-endian value, mutating it.  Does nothing
+    /// on little-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void host_to_little_inplace(T& val) {
         if constexpr (!little_endian)
             byteswap_inplace(val);
     }
 
-    /// Converts a host-order unsigned integer value into a little-endian value, returning it.  Does
-    /// no converstion on little-endian platforms.
+    /// Converts a host-order integer value into a little-endian value, returning it.  Does no
+    /// converstion on little-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T host_to_little(T val) {
         host_to_little_inplace(val);
         return val;
     }
 
-    /// Converts a little-endian unsigned integer value into a host-order (native) integer value,
-    /// mutating it.  Does nothing on little-endian platforms.
+    /// Converts a little-endian integer value into a host-order (native) integer value, mutating
+    /// it.  Does nothing on little-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void little_to_host_inplace(T& val) {
         if constexpr (!little_endian)
             byteswap_inplace(val);
     }
 
-    /// Converts a little-order unsigned integer value into a host-order (native) integer value,
-    /// returning it.  Does no conversion on little-endian platforms.
+    /// Converts a little-order integer value into a host-order (native) integer value, returning
+    /// it.  Does no conversion on little-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T little_to_host(T val) {
         little_to_host_inplace(val);
         return val;
     }
 
-    /// Converts a host-order unsigned integer value into a big-endian value, mutating it.  Does
-    /// nothing on big-endian platforms.
+    /// Converts a host-order integer value into a big-endian value, mutating it.  Does nothing on
+    /// big-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void host_to_big_inplace(T& val) {
         if constexpr (!big_endian)
             byteswap_inplace(val);
     }
 
-    /// Converts a host-order unsigned integer value into a big-endian value, returning it.  Does no
+    /// Converts a host-order integer value into a big-endian value, returning it.  Does no
     /// conversion on big-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T host_to_big(T val) {
@@ -114,24 +114,24 @@ namespace oxenc {
         return val;
     }
 
-    /// Converts a big-endian unsigned value into a host-order (native) integer value, mutating it.
-    /// Does nothing on big-endian platforms.
+    /// Converts a big-endian value into a host-order (native) integer value, mutating it.  Does
+    /// nothing on big-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void big_to_host_inplace(T& val) {
         if constexpr (!big_endian)
             byteswap_inplace(val);
     }
 
-    /// Converts a big-order unsigned integer value into a host-order (native) integer value,
-    /// returning it.  Does no conversion on big-endian platforms.
+    /// Converts a big-order integer value into a host-order (native) integer value, returning it.
+    /// Does no conversion on big-endian platforms.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T big_to_host(T val) {
         big_to_host_inplace(val);
         return val;
     }
 
-    /// Loads a host-order unsigned integer value from a memory location containing little-endian
-    /// bytes.  (There is no alignment requirement on the given pointer address).
+    /// Loads a host-order integer value from a memory location containing little-endian bytes.
+    /// (There is no alignment requirement on the given pointer address).
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T load_little_to_host(const void* from) {
         T val;
@@ -140,8 +140,8 @@ namespace oxenc {
         return val;
     }
 
-    /// Loads a little-endian unsigned integer value from a memory location containing host order
-    /// bytes.  (There is no alignment requirement on the given pointer address).
+    /// Loads a little-endian integer value from a memory location containing host order bytes.
+    /// (There is no alignment requirement on the given pointer address).
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T load_host_to_little(const void* from) {
         T val;
@@ -150,8 +150,8 @@ namespace oxenc {
         return val;
     }
 
-    /// Loads a host-order unsigned integer value from a memory location containing big-endian
-    /// bytes.  (There is no alignment requirement on the given pointer address).
+    /// Loads a host-order integer value from a memory location containing big-endian bytes.  (There
+    /// is no alignment requirement on the given pointer address).
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T load_big_to_host(const void* from) {
         T val;
@@ -160,8 +160,8 @@ namespace oxenc {
         return val;
     }
 
-    /// Loads a big-endian unsigned integer value from a memory location containing host order
-    /// bytes.  (There is no alignment requirement on the given pointer address).
+    /// Loads a big-endian integer value from a memory location containing host order bytes.  (There
+    /// is no alignment requirement on the given pointer address).
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     T load_host_to_big(const void* from) {
         T val;
@@ -170,32 +170,32 @@ namespace oxenc {
         return val;
     }
 
-    /// Writes a little-endian unsigned integer value into the given memory location, copying and
-    /// converting it (if necessary) from the given host-order unsigned integer value.
+    /// Writes a little-endian integer value into the given memory location, copying and converting
+    /// it (if necessary) from the given host-order integer value.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void write_host_as_little(T val, void* to) {
         host_to_little_inplace(val);
         std::memcpy(to, &val, sizeof(T));
     }
 
-    /// Writes a big-endian unsigned integer value into the given memory location, copying and
-    /// converting it (if necessary) from the given host-order unsigned integer value.
+    /// Writes a big-endian integer value into the given memory location, copying and converting it
+    /// (if necessary) from the given host-order integer value.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void write_host_as_big(T val, void* to) {
         host_to_big_inplace(val);
         std::memcpy(to, &val, sizeof(T));
     }
 
-    /// Writes a host-order unsigned integer value into the given memory location, copying and
-    /// converting it (if necessary) from the given little-endian unsigned integer value.
+    /// Writes a host-order integer value into the given memory location, copying and converting it
+    /// (if necessary) from the given little-endian integer value.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void write_little_as_host(T val, void* to) {
         little_to_host_inplace(val);
         std::memcpy(to, &val, sizeof(T));
     }
 
-    /// Writes a host-order unsigned integer value into the given memory location, copying and
-    /// converting it (if necessary) from the given big-endian unsigned integer value.
+    /// Writes a host-order integer value into the given memory location, copying and converting it
+    /// (if necessary) from the given big-endian integer value.
     template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
     void write_big_as_host(T val, void* to) {
         big_to_host_inplace(val);

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -168,3 +168,39 @@ TEST_CASE("native to big", "[endian][big]") {
     write_host_as_big(u64, buf);
     CHECK( buffer.substr(0, 8) == "\x01\x23\x45\x67\x89\xab\xcd\xef" );
 }
+
+TEST_CASE("signed values", "[endian][signed]") {
+    int8_t i8 = 0x01;
+    int16_t i16 = 0x0123;
+    int32_t i32 = 0x01234567;
+    int64_t i64 = 0x0123456789abcdef;
+
+#ifdef __LITTLE_ENDIAN__
+    constexpr int8_t i8_little = 0x01;
+    constexpr int16_t i16_little = 0x0123;
+    constexpr int32_t i32_little = 0x01234567;
+    constexpr int64_t i64_little = 0x0123456789abcdef;
+    constexpr int8_t i8_big = 0x01;
+    constexpr int16_t i16_big = 0x2301;
+    constexpr int32_t i32_big = 0x67452301;
+    constexpr int64_t i64_big = -0x1032547698badcff;
+#else
+    constexpr int8_t i8_little = 0x01;
+    constexpr int16_t i16_little = 0x2301;
+    constexpr int32_t i32_little = 0x67452301;
+    constexpr int64_t i64_little = -0x1032547698badcff;
+    constexpr int8_t i8_big = 0x01;
+    constexpr int16_t i16_big = 0x0123;
+    constexpr int32_t i32_big = 0x01234567;
+    constexpr int64_t i64_big = 0x0123456789abcdef;
+#endif
+
+    CHECK( host_to_little(i8) == i8_little );
+    CHECK( host_to_little(i16) == i16_little );
+    CHECK( host_to_little(i32) == i32_little );
+    CHECK( host_to_little(i64) == i64_little );
+    CHECK( host_to_big(i8) == i8_big );
+    CHECK( host_to_big(i16) == i16_big );
+    CHECK( host_to_big(i32) == i32_big );
+    CHECK( host_to_big(i64) == i64_big );
+}


### PR DESCRIPTION
There's no reason this needs to be restricted to unsigned.