### PR TITLE
Fix endian detection

### DIFF
--- a/oxenc/endian.h
+++ b/oxenc/endian.h
@@ -22,27 +22,29 @@ extern "C" {
 #  error "Don't know how to byteswap on this platform!"
 #endif
 
-#if !defined(__LITTLE_ENDIAN__) && defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) \
-    && __BYTE_ORDER == __LITTLE_ENDIAN
-#  define __LITTLE_ENDIAN__
-#elif !defined(__BIG_ENDIAN__) && defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) \
-    && __BYTE_ORDER == __BIG_ENDIAN
-#  define __BIG_ENDIAN__
-#elif defined(_WIN32)
-#  define __LITTLE_ENDIAN__
-#elif !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-#  error "Error: don't know which endian this is"
-#endif
-
 namespace oxenc {
 
     /// True if this is a little-endian platform
     inline constexpr bool little_endian =
-#ifdef __LITTLE_ENDIAN__
-        true;
+#if defined(__LITTLE_ENDIAN__)
+        true
+#elif defined(__BIG_ENDIAN__)
+        false
+#elif defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN
+        true
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        true
+#elif defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN
+        false
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        false
+#elif defined(_WIN32)
+        true
 #else
-        false;
+#  error "Error: don't know which endian this is"
 #endif
+        ;
+
     /// True if this is a big-endian platform
     inline constexpr bool big_endian = !little_endian;
 

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -25,17 +25,10 @@ TEST_CASE("native to little", "[endian][little]") {
     uint32_t u32 = 0x01234567;
     uint64_t u64 = 0x0123456789abcdef;
 
-#ifdef __LITTLE_ENDIAN__
     constexpr uint8_t u8_little = 0x01;
-    constexpr uint16_t u16_little = 0x0123;
-    constexpr uint32_t u32_little = 0x01234567;
-    constexpr uint64_t u64_little = 0x0123456789abcdef;
-#else
-    constexpr uint8_t u8_little = 0x01;
-    constexpr uint16_t u16_little = 0x2301;
-    constexpr uint32_t u32_little = 0x67452301;
-    constexpr uint64_t u64_little = 0xefcdab8967452301;
-#endif
+    constexpr uint16_t u16_little = little_endian ? 0x0123 : 0x2301;
+    constexpr uint32_t u32_little = little_endian ? 0x01234567 : 0x67452301;
+    constexpr uint64_t u64_little = little_endian ? 0x0123456789abcdef : 0xefcdab8967452301;
 
     CHECK( host_to_little(u8) == u8_little );
     CHECK( host_to_little(u16) == u16_little );
@@ -175,25 +168,14 @@ TEST_CASE("signed values", "[endian][signed]") {
     int32_t i32 = 0x01234567;
     int64_t i64 = 0x0123456789abcdef;
 
-#ifdef __LITTLE_ENDIAN__
     constexpr int8_t i8_little = 0x01;
-    constexpr int16_t i16_little = 0x0123;
-    constexpr int32_t i32_little = 0x01234567;
-    constexpr int64_t i64_little = 0x0123456789abcdef;
+    constexpr int16_t i16_little = little_endian ? 0x0123 : 0x2301;
+    constexpr int32_t i32_little = little_endian ? 0x01234567 : 0x67452301;
+    constexpr int64_t i64_little = little_endian ? 0x0123456789abcdef : -0x1032547698badcff;
     constexpr int8_t i8_big = 0x01;
-    constexpr int16_t i16_big = 0x2301;
-    constexpr int32_t i32_big = 0x67452301;
-    constexpr int64_t i64_big = -0x1032547698badcff;
-#else
-    constexpr int8_t i8_little = 0x01;
-    constexpr int16_t i16_little = 0x2301;
-    constexpr int32_t i32_little = 0x67452301;
-    constexpr int64_t i64_little = -0x1032547698badcff;
-    constexpr int8_t i8_big = 0x01;
-    constexpr int16_t i16_big = 0x0123;
-    constexpr int32_t i32_big = 0x01234567;
-    constexpr int64_t i64_big = 0x0123456789abcdef;
-#endif
+    constexpr int16_t i16_big = little_endian ? 0x2301 : 0x0123;
+    constexpr int32_t i32_big = little_endian ? 0x67452301 : 0x01234567;
+    constexpr int64_t i64_big = little_endian ? -0x1032547698badcff : 0x0123456789abcdef;
 
     CHECK( host_to_little(i8) == i8_little );
     CHECK( host_to_little(i16) == i16_little );


### PR DESCRIPTION
The macros we were looking at were failing sometimes on GCC, though for
some reason not in the test suite (perhaps because catch2 includes
something that defines `__LITTLE_ENDIAN__` etc?).

This updates to properly check GCC's endian definitions as well.

Also avoids defining macros for any of this.