### PR TITLE
bt_dict_producer fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(oxenc
-    VERSION 1.0.3
+    VERSION 1.0.4
     DESCRIPTION "oxenc - Base 16/32/64 and Bittorrent Encoding/Decoding Header Only Library"
     LANGUAGES CXX)
 

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -73,8 +73,8 @@ namespace oxenc {
         const char* to;
 
         // Sublist constructors
-        inline bt_list_producer(bt_list_producer* parent, std::string_view prefix = "l"sv);
-        inline bt_list_producer(bt_dict_producer* parent, std::string_view prefix = "l"sv);
+        bt_list_producer(bt_list_producer* parent, std::string_view prefix = "l"sv);
+        bt_list_producer(bt_dict_producer* parent, std::string_view prefix = "l"sv);
 
         // Does the actual appending to the buffer, and throwing if we'd overrun.  If advance is false
         // then we append without moving the buffer pointer (primarily when we append intermediate `e`s
@@ -131,17 +131,17 @@ namespace oxenc {
         bt_list_producer(const bt_list_producer&) = delete;
         bt_list_producer& operator=(const bt_list_producer&) = delete;
         bt_list_producer& operator=(bt_list_producer&&) = delete;
-        inline bt_list_producer(bt_list_producer&& other);
+        bt_list_producer(bt_list_producer&& other);
 
         /// Constructs a list producer that writes into the range [begin, end).  If a write would go
         /// beyond the end of the buffer an exception is raised.  Note that this will happen during
         /// construction if the given buffer is not large enough to contain the `le` encoding of an
         /// empty list.
-        inline bt_list_producer(char* begin, char* end);
+        bt_list_producer(char* begin, char* end) : bt_list_producer{begin, end, "l"sv} {}
 
         /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
         /// go beyond the end of the buffer an exception is raised.
-        bt_list_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len} {}
+        bt_list_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "l"sv} {}
 
         ~bt_list_producer();
 
@@ -201,7 +201,7 @@ namespace oxenc {
         ///
         /// If doing more complex lifetime management, take care not to allow the child instance to
         /// outlive the parent.
-        inline bt_list_producer append_list();
+        bt_list_producer append_list();
 
         /// Appends a dict to this list.  Returns a new bt_dict_producer that references the parent
         /// list.  The parent cannot be added to until the subdict is destroyed.  This is meant to be
@@ -209,7 +209,7 @@ namespace oxenc {
         ///
         /// If doing more complex lifetime management, take care not to allow the child instance to
         /// outlive the parent.
-        inline bt_dict_producer append_dict();
+        bt_dict_producer append_dict();
     };
 
 

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -76,6 +76,9 @@ namespace oxenc {
         bt_list_producer(bt_list_producer* parent, std::string_view prefix = "l"sv);
         bt_list_producer(bt_dict_producer* parent, std::string_view prefix = "l"sv);
 
+        // Common constructor for both list and dict producer
+        bt_list_producer(char* begin, char* end, std::string_view prefix);
+
         // Does the actual appending to the buffer, and throwing if we'd overrun.  If advance is false
         // then we append without moving the buffer pointer (primarily when we append intermediate `e`s
         // that we will overwrite if more data is added).  This means that the next write will overwrite
@@ -242,13 +245,23 @@ namespace oxenc {
 #endif
 
     public:
-        // Construction is identical to bt_list_producer
-        using bt_list_producer::bt_list_producer;
+        /// Constructs a dict producer that writes into the range [begin, end).  If a write would go
+        /// beyond the end of the buffer an exception is raised.  Note that this will happen during
+        /// construction if the given buffer is not large enough to contain the `de` encoding of an
+        /// empty list.
+        bt_dict_producer(char* begin, char* end) : bt_list_producer{begin, end, "d"sv} {}
+
+        /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
+        /// go beyond the end of the buffer an exception is raised.
+        bt_dict_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "d"sv} {}
 
         /// Returns a string_view into the currently serialized data buffer.  Note that the returned
         /// view includes the `e` dict end serialization markers which will be overwritten if the dict
         /// (or an active sublist/subdict) is appended to.
         std::string_view view() const { return bt_list_producer::view(); }
+
+        /// Returns the end position in the buffer.
+        const char* end() const { return bt_list_producer::end(); }
 
         /// Appends a key-value pair with a string or integer value.  The key must be > the last key
         /// added, but this is only enforced (with an assertion) in debug builds.
@@ -403,9 +416,9 @@ namespace oxenc {
             data);
     }
 
-    inline bt_list_producer::bt_list_producer(char* begin, char* end)
+    inline bt_list_producer::bt_list_producer(char* begin, char* end, std::string_view prefix)
         : data{buf_span{begin, end}}, buffer{*std::get_if<buf_span>(&data)}, from{buffer.first} {
-        buffer_append("l"sv);
+        buffer_append(prefix);
         append_intermediate_ends();
     }
 


### PR DESCRIPTION
- `end()` was not public
- produced dicts started with `l` instead of `d`
- no tests for bt_dict_producer