### PR TITLE
Add bt_value/dict/list support to bt_..._producer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(oxenc
-    VERSION 1.0.4
+    VERSION 1.0.5
     DESCRIPTION "oxenc - Base 16/32/64 and Bittorrent Encoding/Decoding Header Only Library"
     LANGUAGES CXX)
 

--- a/oxenc/bt.h
+++ b/oxenc/bt.h
@@ -2,3 +2,4 @@
 #include "bt_value.h"
 #include "bt_serialize.h"
 #include "bt_producer.h"
+#include "bt_value_producer.h"

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -213,6 +213,11 @@ namespace oxenc {
         /// If doing more complex lifetime management, take care not to allow the child instance to
         /// outlive the parent.
         bt_dict_producer append_dict();
+
+        /// Appends a bt_value, bt_dict, or bt_list to this bt_list.  You must include the
+        /// bt_value_producer.h header (either directly or via bt.h) to use this method.
+        template <typename T>
+        void append_bt(const T& bt);
     };
 
 
@@ -341,6 +346,11 @@ namespace oxenc {
             check_incrementing_key(key.size());
             return bt_list_producer{this};
         }
+
+        /// Appends a bt_value, bt_dict, or bt_list to this bt_dict.  You must include the
+        /// bt_value_producer.h header (either directly or via bt.h) to use this method.
+        template <typename T>
+        void append_bt(std::string_view key, const T& bt);
     };
 
     inline bt_list_producer::bt_list_producer(bt_list_producer* parent, std::string_view prefix)

--- a/oxenc/bt_value_producer.h
+++ b/oxenc/bt_value_producer.h
@@ -1,0 +1,99 @@
+#include "bt_producer.h"
+#include "bt_value.h"
+#include "variant.h"
+#include <type_traits>
+
+/// This header provides the implementations of append_bt(bt_value/bt_list/bt_dict) for
+/// bt_serialize.  (It is optional to avoid unnecessary includes when not wanted).
+
+namespace oxenc {
+
+    namespace detail {
+
+        void serialize_list(bt_list_producer& out, const bt_list& l);
+        void serialize_dict(bt_dict_producer& out, const bt_dict& l);
+
+        struct dict_appender {
+            bt_dict_producer& out;
+            std::string_view key;
+            dict_appender(bt_dict_producer& out, std::string_view key)
+                : out{out}, key{key} {}
+
+            void operator()(const bt_dict& d) {
+                auto subdict = out.append_dict(key);
+                serialize_dict(subdict, d);
+            }
+            void operator()(const bt_list& l) {
+                auto sublist = out.append_list(key);
+                serialize_list(sublist, l);
+            }
+            template <typename T>
+            void operator()(const T& other) {
+                out.append(key, other);
+            }
+        };
+
+        struct list_appender {
+            bt_list_producer& out;
+            explicit list_appender(bt_list_producer& out)
+                : out{out} {}
+
+            void operator()(const bt_dict& d) {
+                auto subdict = out.append_dict();
+                serialize_dict(subdict, d);
+            }
+            void operator()(const bt_list& l) {
+                auto sublist = out.append_list();
+                serialize_list(sublist, l);
+            }
+            template <typename T>
+            void operator()(const T& other) {
+                out.append(other);
+            }
+        };
+
+        inline void serialize_dict(bt_dict_producer& out, const bt_dict& d) {
+            for (const auto& [k, v]: d)
+                var::visit(dict_appender{out, k}, v);
+        }
+
+        inline void serialize_list(bt_list_producer& out, const bt_list& l) {
+            for (auto& val : l)
+                var::visit(list_appender{out}, val);
+        }
+    }
+
+    template <>
+    inline void bt_list_producer::append_bt(const bt_dict& bt) {
+        auto subdict = append_dict();
+        detail::serialize_dict(subdict, bt);
+    }
+
+    template <>
+    inline void bt_list_producer::append_bt(const bt_list& bt) {
+        auto sublist = append_list();
+        detail::serialize_list(sublist, bt);
+    }
+
+    template <>
+    inline void bt_list_producer::append_bt(const bt_value& bt) {
+        var::visit(detail::list_appender{*this}, bt);
+    }
+
+    template <>
+    inline void bt_dict_producer::append_bt(std::string_view key, const bt_dict& bt) {
+        auto subdict = append_dict(key);
+        detail::serialize_dict(subdict, bt);
+    }
+
+    template <>
+    inline void bt_dict_producer::append_bt(std::string_view key, const bt_list& bt) {
+        auto sublist = append_list(key);
+        detail::serialize_list(sublist, bt);
+    }
+
+    template <>
+    inline void bt_dict_producer::append_bt(std::string_view key, const bt_value& bt) {
+        var::visit(detail::dict_appender{*this, key}, bt);
+    }
+}

--- a/oxenc/bt_value_producer.h
+++ b/oxenc/bt_value_producer.h
@@ -54,12 +54,12 @@ namespace oxenc {
 
         inline void serialize_dict(bt_dict_producer& out, const bt_dict& d) {
             for (const auto& [k, v]: d)
-                var::visit(dict_appender{out, k}, v);
+                var::visit(dict_appender{out, k}, static_cast<const bt_variant&>(v));
         }
 
         inline void serialize_list(bt_list_producer& out, const bt_list& l) {
             for (auto& val : l)
-                var::visit(list_appender{out}, val);
+                var::visit(list_appender{out}, static_cast<const bt_variant&>(val));
         }
     }
 
@@ -77,7 +77,7 @@ namespace oxenc {
 
     template <>
     inline void bt_list_producer::append_bt(const bt_value& bt) {
-        var::visit(detail::list_appender{*this}, bt);
+        var::visit(detail::list_appender{*this}, static_cast<const bt_variant&>(bt));
     }
 
     template <>
@@ -94,6 +94,6 @@ namespace oxenc {
 
     template <>
     inline void bt_dict_producer::append_bt(std::string_view key, const bt_value& bt) {
-        var::visit(detail::dict_appender{*this, key}, bt);
+        var::visit(detail::dict_appender{*this, key}, static_cast<const bt_variant&>(bt));
     }
 }

--- a/tests/test_bt.cpp
+++ b/tests/test_bt.cpp
@@ -324,6 +324,37 @@ TEST_CASE("bt allocation-free dict producer", "[bt][dict][producer]") {
         "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:0:e1:qi1e1:ri2e1:~i3e2:~1i4ee"sv );
 }
 
+TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {
+
+    char buf[1024];
+    bt_dict_producer x{buf, sizeof(buf)};
+
+    bt_dict more{
+        {"b", 1},
+        {"c", bt_dict{
+            {"d", "e"},
+            {"f", bt_list{{1,2,3}}}
+        }}
+    };
+    bt_dict tiny{{"a", ""}};
+
+    x.append("a", 42);
+    x.append_bt("x", bt_value{tiny});
+    x.append_bt("y", bt_list{{tiny}});
+    x.append_bt("z", more);
+
+    CHECK( x.view() == "d1:ai42e1:xd1:a0:e1:yld1:a0:ee1:zd1:bi1e1:cd1:d1:e1:fli1ei2ei3eeeee" );
+
+    bt_list_producer y{buf, sizeof(buf)};
+    y.append(123);
+    y.append_bt(more);
+    y.append_bt(bt_value{tiny});
+    y.append_bt(bt_list{{tiny}});
+    y.append("~");
+
+    CHECK( y.view() == "li123ed1:bi1e1:cd1:d1:e1:fli1ei2ei3eeeed1:a0:eld1:a0:ee1:~e" );
+}
+
 #ifdef OXENC_APPLE_TO_CHARS_WORKAROUND
 TEST_CASE("apple to_chars workaround test", "[bt][apple][sucks]") {
     char buf[20];


### PR DESCRIPTION
This allows you to build a dict or list that contains an existing bt_value (or bt_list or bt_dict) as a subvalue without having to put the whole thing into a bt_value first.  The implementation doesn't require extra allocations (i.e. it traverses the value, serializing directly into the producer buffer rather than serializing separately).