### PR TITLE
Add _hex, _b32z, _b64 user-defined literals

### DIFF
--- a/oxenc/base32z.h
+++ b/oxenc/base32z.h
@@ -272,4 +272,13 @@ template <typename CharT>
 std::string from_base32z(std::basic_string_view<CharT> s) { return from_base32z(s.begin(), s.end()); }
 inline std::string from_base32z(std::string_view s) { return from_base32z<>(s); }
 
+inline namespace literals {
+    inline std::string operator""_b32z(const char* x, size_t n) {
+        std::string_view in{x, n};
+        if (!is_base32z(in))
+            throw std::invalid_argument{"base32z literal is not base32z"};
+        return from_base32z(in);
+    }
+}
+
 }

--- a/oxenc/base64.h
+++ b/oxenc/base64.h
@@ -342,4 +342,13 @@ template <typename CharT>
 std::string from_base64(std::basic_string_view<CharT> s) { return from_base64(s.begin(), s.end()); }
 inline std::string from_base64(std::string_view s) { return from_base64<>(s); }
 
+inline namespace literals {
+    inline std::string operator""_b64(const char* x, size_t n) {
+        std::string_view in{x, n};
+        if (!is_base64(in))
+            throw std::invalid_argument{"base64 literal is not base64"};
+        return from_base64(in);
+    }
+}
+
 }

--- a/oxenc/hex.h
+++ b/oxenc/hex.h
@@ -221,4 +221,13 @@ template <typename CharT>
 std::string from_hex(std::basic_string_view<CharT> s) { return from_hex(s.begin(), s.end()); }
 inline std::string from_hex(std::string_view s) { return from_hex<>(s); }
 
+inline namespace literals {
+    inline std::string operator""_hex(const char* x, size_t n) {
+        std::string_view in{x, n};
+        if (!is_hex(in))
+            throw std::invalid_argument{"hex literal is not hex"};
+        return from_hex(in);
+    }
+}
+
 }

--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -2,6 +2,7 @@
 #include <iterator>
 
 using namespace std::literals;
+using namespace oxenc::literals;
 
 const std::string pk = "\xf1\x6b\xa5\x59\x10\x39\xf0\x89\xb4\x2a\x83\x41\x75\x09\x30\x94\x07\x4d\x0d\x93\x7a\x79\xe5\x3e\x5c\xe7\x30\xf9\x46\xe1\x4b\x88";
 const std::string pk_hex = "f16ba5591039f089b42a834175093094074d0d937a79e53e5ce730f946e14b88";
@@ -19,6 +20,9 @@ TEST_CASE("hex encoding/decoding", "[encoding][decoding][hex]") {
     REQUIRE( oxenc::to_hex(chars.begin(), chars.end()) == "010a64fe" );
 
     REQUIRE( oxenc::from_hex("12345678ffEDbca9") == "\x12\x34\x56\x78\xff\xed\xbc\xa9"s );
+    REQUIRE( "12345678ffEDbca9"_hex == "\x12\x34\x56\x78\xff\xed\xbc\xa9"s );
+    REQUIRE_THROWS_AS( "abc"_hex, std::invalid_argument );
+    REQUIRE_THROWS_AS( "abcg"_hex, std::invalid_argument );
 
     REQUIRE( oxenc::is_hex("1234567890abcdefABCDEF1234567890abcdefABCDEF") );
     REQUIRE_FALSE( oxenc::is_hex("1234567890abcdefABCDEF1234567890aGcdefABCDEF") );
@@ -79,6 +83,12 @@ TEST_CASE("base32z encoding/decoding", "[encoding][decoding][base32z]") {
 
     REQUIRE( oxenc::from_base32z("YRTWK3HJIXG66YJDEIUAUK6P7HY1GTM8TGIH55ABRPNSXNPM3ZZO")
             == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+
+    REQUIRE( "yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo"_b32z
+            == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+    REQUIRE( "YRTWK3HJIXG66YJDEIUAUK6P7HY1GTM8TGIH55ABRPNSXNPM3ZZO"_b32z
+            == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+    REQUIRE_THROWS_AS( "abcl"_b32z, std::invalid_argument );
 
     auto five_nulls = oxenc::from_base32z("yyyyyyyy");
     REQUIRE( five_nulls.size() == 5 );
@@ -243,6 +253,10 @@ TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
             "animals, which is a lust of the mind, that by a perseverance of delight in the "
             "continued and indefatigable generation of knowledge, exceeds the short vehemence of "
             "any carnal pleasure.");
+
+    REQUIRE( "SGVsbG8="_b64 == "Hello" );
+    REQUIRE( "SGVsbG8"_b64 == "Hello" );
+    REQUIRE_THROWS_AS( "SGVsbG8$"_b64, std::invalid_argument );
 
     REQUIRE( oxenc::to_base64(pk) == pk_b64 );
     REQUIRE( oxenc::to_base64(pk.begin(), pk.end()) == pk_b64 );


### PR DESCRIPTION
This lets you write:

```C++
    using namespace oxenc::literals;
    auto hello = "68656c6c6f"_hex;
```

to get the std::string "hello", and similar for base32z or base64 literals.  This is obviously useless for "hello" but is quite useful when you have an arbitrary binary value on hand without having to make an explicit call to oxenc::to_hex(...).