### PR TITLE
variant.h: minor fixes for Darwin

### DIFF
--- a/oxenc/variant.h
+++ b/oxenc/variant.h
@@ -14,7 +14,7 @@
 #include <variant>
 
 #ifdef __APPLE__
-#  include <AvailabilityVersions.h>
+#  include <AvailabilityMacros.h>
 #  if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14
 #    define BROKEN_APPLE_VARIANT
 #  endif

--- a/oxenc/variant.h
+++ b/oxenc/variant.h
@@ -15,7 +15,7 @@
 
 #ifdef __APPLE__
 #  include <AvailabilityMacros.h>
-#  if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14
+#  if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 101400)
 #    define BROKEN_APPLE_VARIANT
 #  endif
 #endif


### PR DESCRIPTION
This merely fixes macros in use:
1. Appropriate header to include is `AvailabilityMacros.h`, which is actually available in every macOS.
2. MAC_OS_X_VERSION_10_14 is not defined prior to 10.14, so condition is wrong. Numerical constant is to be used.