### PR TITLE
Add std::string building to bt producers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,47 @@
+
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlines: Left
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: 'true'
+AllowAllArgumentsOnNextLine: 'true'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: 'true'
+BreakConstructorInitializers: AfterColon
+Cpp11BracedListStyle: 'true'
+KeepEmptyLinesAtTheStartOfBlocks: 'true'
+NamespaceIndentation: Inner
+CompactNamespaces: 'true'
+PenaltyBreakString: '3'
+SpaceBeforeParens: ControlStatements
+SpacesInAngles: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: c++17
+UseTab: Never
+SortIncludes: true
+ColumnLimit: 100
+IndentWidth: 4
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+
+
+# treat pointers and reference declarations as if part of the type
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# when wrapping function calls/declarations, force each parameter to have its own line
+BinPackParameters: 'false'
+BinPackArguments: 'false'

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -105,7 +105,7 @@ local full_llvm(version) = debian_pipeline(
       submodules,
       {
         name: 'build',
-        image: docker_base + 'debian-win32-cross',
+        image: docker_base + 'debian-win32-cross-wine',
         pull: 'always',
         commands: [
           'echo "Building on ${DRONE_STAGE_MACHINE}"',
@@ -120,7 +120,7 @@ local full_llvm(version) = debian_pipeline(
           'cmake .. -G Ninja -DCMAKE_CXX_COMPILER=/usr/bin/x86_64-w64-mingw32-g++-posix -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_CXX_COMPILER_LAUNCHER=ccache',
           'ninja -v',
           'export WINEPATH="$$(dirname $$(/usr/bin/x86_64-w64-mingw32-g++-posix -print-libgcc-file-name));/usr/x86_64-w64-mingw32/lib"',
-          'wine64-stable ./tests/tests.exe --use-colour yes',
+          'WINEDEBUG=-all wine-stable ./tests/tests.exe --use-colour yes',
         ],
       },
     ],

--- a/oxenc/base32z.h
+++ b/oxenc/base32z.h
@@ -1,70 +1,80 @@
 #pragma once
+#include <array>
+#include <cassert>
+#include <iterator>
+#include <stdexcept>
 #include <string>
 #include <string_view>
-#include <array>
-#include <iterator>
-#include <cassert>
-#include <stdexcept>
+
 #include "byte_type.h"
 
 namespace oxenc {
 
 namespace detail {
 
-/// Compile-time generated lookup tables for base32z conversion.  This is case insensitive (though
-/// for byte -> b32z conversion we always produce lower case).
-struct b32z_table {
-    // Store the 0-31 decoded value of every possible char; all the chars that aren't valid are set
-    // to 0.  (If you don't trust your data, check it with is_base32z first, which uses these 0's
-    // to detect invalid characters -- which is why we want a full 256 element array).
-    char from_b32z_lut[256];
-    // Store the encoded character of every 0-31 (5 bit) value.
-    char to_b32z_lut[32];
+    /// Compile-time generated lookup tables for base32z conversion.  This is case insensitive
+    /// (though for byte -> b32z conversion we always produce lower case).
+    struct b32z_table {
+        // Store the 0-31 decoded value of every possible char; all the chars that aren't valid are
+        // set to 0.  (If you don't trust your data, check it with is_base32z first, which uses
+        // these 0's to detect invalid characters -- which is why we want a full 256 element array).
+        char from_b32z_lut[256];
+        // Store the encoded character of every 0-31 (5 bit) value.
+        char to_b32z_lut[32];
 
-    // constexpr constructor that fills out the above (and should do it at compile time for any half
-    // decent compiler).
-    constexpr b32z_table() noexcept : from_b32z_lut{},
-              to_b32z_lut{
-                  'y', 'b', 'n', 'd', 'r', 'f', 'g', '8', 'e', 'j', 'k', 'm', 'c', 'p', 'q', 'x',
-                  'o', 't', '1', 'u', 'w', 'i', 's', 'z', 'a', '3', '4', '5', 'h', '7', '6', '9'
-              }
-    {
-        for (unsigned char c = 0; c < 32; c++) {
-            unsigned char x = to_b32z_lut[c];
-            from_b32z_lut[x] = c;
-            if (x >= 'a' && x <= 'z')
-                from_b32z_lut[x - 'a' + 'A'] = c;
+        // constexpr constructor that fills out the above (and should do it at compile time for any
+        // half decent compiler).
+        constexpr b32z_table() noexcept :
+                from_b32z_lut{}, to_b32z_lut{'y', 'b', 'n', 'd', 'r', 'f', 'g', '8', 'e', 'j', 'k',
+                                             'm', 'c', 'p', 'q', 'x', 'o', 't', '1', 'u', 'w', 'i',
+                                             's', 'z', 'a', '3', '4', '5', 'h', '7', '6', '9'} {
+            for (unsigned char c = 0; c < 32; c++) {
+                unsigned char x = to_b32z_lut[c];
+                from_b32z_lut[x] = c;
+                if (x >= 'a' && x <= 'z')
+                    from_b32z_lut[x - 'a' + 'A'] = c;
+            }
         }
-    }
-    // Convert a b32z encoded character into a 0-31 value
-    constexpr char from_b32z(unsigned char c) const noexcept { return from_b32z_lut[c]; }
-    // Convert a 0-31 value into a b32z encoded character
-    constexpr char to_b32z(unsigned char b) const noexcept { return to_b32z_lut[b]; }
-};
-inline constexpr b32z_table b32z_lut{};
+        // Convert a b32z encoded character into a 0-31 value
+        constexpr char from_b32z(unsigned char c) const noexcept { return from_b32z_lut[c]; }
+        // Convert a 0-31 value into a b32z encoded character
+        constexpr char to_b32z(unsigned char b) const noexcept { return to_b32z_lut[b]; }
+    };
+    inline constexpr b32z_table b32z_lut{};
 
-// This main point of this static assert is to force the compiler to compile-time build the constexpr tables.
-static_assert(b32z_lut.from_b32z('w') == 20 && b32z_lut.from_b32z('T') == 17 && b32z_lut.to_b32z(5) == 'f', "");
+    // This main point of this static assert is to force the compiler to compile-time build the
+    // constexpr tables.
+    static_assert(
+            b32z_lut.from_b32z('w') == 20 && b32z_lut.from_b32z('T') == 17 &&
+                    b32z_lut.to_b32z(5) == 'f',
+            "");
 
-} // namespace detail
+}  // namespace detail
 
-/// Returns the number of characters required to encode a base32z string from the given number of bytes.
-inline constexpr size_t to_base32z_size(size_t byte_size) { return (byte_size*8 + 4) / 5; } // ⌈bits/5⌉ because 5 bits per byte
+/// Returns the number of characters required to encode a base32z string from the given number of
+/// bytes.
+inline constexpr size_t to_base32z_size(size_t byte_size) {
+    return (byte_size * 8 + 4) / 5;
+}  // ⌈bits/5⌉ because 5 bits per byte
 /// Returns the (maximum) number of bytes required to decode a base32z string of the given size.
-inline constexpr size_t from_base32z_size(size_t b32z_size) { return b32z_size*5 / 8; } // ⌊bits/8⌋
+inline constexpr size_t from_base32z_size(size_t b32z_size) {
+    return b32z_size * 5 / 8;
+}  // ⌊bits/8⌋
 
 /// Iterable object for on-the-fly base32z encoding.  Used internally, but also particularly useful
 /// when converting from one encoding to another.
 template <typename InputIt>
 struct base32z_encoder final {
-private:
+  private:
     InputIt _it, _end;
-    static_assert(sizeof(decltype(*_it)) == 1, "base32z_encoder requires chars/bytes input iterator");
+    static_assert(
+            sizeof(decltype(*_it)) == 1, "base32z_encoder requires chars/bytes input iterator");
     // Number of bits held in r; will always be >= 5 until we are at the end.
     int bits{_it != _end ? 8 : 0};
     // Holds bits of data we've already read, which might belong to current or next chars
     uint_fast16_t r{bits ? static_cast<unsigned char>(*_it) : (unsigned char)0};
-public:
+
+  public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = char;
@@ -97,7 +107,11 @@ public:
         }
         return *this;
     }
-    base32z_encoder operator++(int) { base32z_encoder copy{*this}; ++*this; return copy; }
+    base32z_encoder operator++(int) {
+        base32z_encoder copy{*this};
+        ++*this;
+        return copy;
+    }
 
     char operator*() {
         // Right-shift off the excess bits we aren't accessing yet
@@ -119,7 +133,9 @@ OutputIt to_base32z(InputIt begin, InputIt end, OutputIt out) {
 template <typename It>
 std::string to_base32z(It begin, It end) {
     std::string base32z;
-    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<It>::iterator_category>) {
+    if constexpr (std::is_base_of_v<
+                          std::random_access_iterator_tag,
+                          typename std::iterator_traits<It>::iterator_category>) {
         using std::distance;
         base32z.reserve(to_base32z_size(distance(begin, end)));
     }
@@ -129,8 +145,12 @@ std::string to_base32z(It begin, It end) {
 
 /// Creates a base32z string from an iterable, std::string-like object
 template <typename CharT>
-std::string to_base32z(std::basic_string_view<CharT> s) { return to_base32z(s.begin(), s.end()); }
-inline std::string to_base32z(std::string_view s) { return to_base32z<>(s); }
+std::string to_base32z(std::basic_string_view<CharT> s) {
+    return to_base32z(s.begin(), s.end());
+}
+inline std::string to_base32z(std::string_view s) {
+    return to_base32z<>(s);
+}
 
 /// Returns true if the given [begin, end) range is an acceptable base32z string: specifically every
 /// character must be in the base32z alphabet, and the string must be a valid encoding length that
@@ -139,11 +159,13 @@ template <typename It>
 constexpr bool is_base32z(It begin, It end) {
     static_assert(sizeof(decltype(*begin)) == 1, "is_base32z requires chars/bytes");
     size_t count = 0;
-    constexpr bool random = std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<It>::iterator_category>;
+    constexpr bool random = std::is_base_of_v<
+            std::random_access_iterator_tag,
+            typename std::iterator_traits<It>::iterator_category>;
     if constexpr (random) {
         using std::distance;
         count = distance(begin, end) % 8;
-        if (count == 1 || count == 3 || count == 6) // see below
+        if (count == 1 || count == 3 || count == 6)  // see below
             return false;
     }
     for (; begin != end; ++begin) {
@@ -167,8 +189,12 @@ constexpr bool is_base32z(It begin, It end) {
 
 /// Returns true if all elements in the string-like value are base32z characters
 template <typename CharT>
-constexpr bool is_base32z(std::basic_string_view<CharT> s) { return is_base32z(s.begin(), s.end()); }
-constexpr bool is_base32z(std::string_view s) { return is_base32z<>(s); }
+constexpr bool is_base32z(std::basic_string_view<CharT> s) {
+    return is_base32z(s.begin(), s.end());
+}
+constexpr bool is_base32z(std::string_view s) {
+    return is_base32z<>(s);
+}
 
 /// Iterable object for on-the-fly base32z decoding.  Used internally, but also particularly useful
 /// when converting from one encoding to another.  The input range must be a valid base32z
@@ -180,12 +206,13 @@ constexpr bool is_base32z(std::string_view s) { return is_base32z<>(s); }
 /// \ff\ff output string.
 template <typename InputIt>
 struct base32z_decoder final {
-private:
+  private:
     InputIt _it, _end;
-    static_assert(sizeof(decltype(*_it)) == 1, "base32z_decoder requires chars/bytes input iterator");
+    static_assert(
+            sizeof(decltype(*_it)) == 1, "base32z_decoder requires chars/bytes input iterator");
     uint_fast16_t in = 0;
-    int bits = 0; // number of bits loaded into `in`; will be in [8, 12] until we hit the end
-public:
+    int bits = 0;  // number of bits loaded into `in`; will be in [8, 12] until we hit the end
+  public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = char;
@@ -209,16 +236,17 @@ public:
             load_byte();
         return *this;
     }
-    base32z_decoder operator++(int) { base32z_decoder copy{*this}; ++*this; return copy; }
-
-    char operator*() {
-        return in >> (bits - 8);
+    base32z_decoder operator++(int) {
+        base32z_decoder copy{*this};
+        ++*this;
+        return copy;
     }
 
-private:
+    char operator*() { return in >> (bits - 8); }
+
+  private:
     void load_in() {
-        in = in << 5
-            | detail::b32z_lut.from_b32z(static_cast<unsigned char>(*_it));
+        in = in << 5 | detail::b32z_lut.from_b32z(static_cast<unsigned char>(*_it));
         bits += 5;
     }
 
@@ -260,7 +288,9 @@ OutputIt from_base32z(InputIt begin, InputIt end, OutputIt out) {
 template <typename It>
 std::string from_base32z(It begin, It end) {
     std::string bytes;
-    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<It>::iterator_category>) {
+    if constexpr (std::is_base_of_v<
+                          std::random_access_iterator_tag,
+                          typename std::iterator_traits<It>::iterator_category>) {
         using std::distance;
         bytes.reserve(from_base32z_size(distance(begin, end)));
     }
@@ -271,8 +301,12 @@ std::string from_base32z(It begin, It end) {
 /// Converts base32z digits from a std::string-like object into a std::string of bytes.  Undefined
 /// behaviour if any characters are not valid (case-insensitive) base32z characters.
 template <typename CharT>
-std::string from_base32z(std::basic_string_view<CharT> s) { return from_base32z(s.begin(), s.end()); }
-inline std::string from_base32z(std::string_view s) { return from_base32z<>(s); }
+std::string from_base32z(std::basic_string_view<CharT> s) {
+    return from_base32z(s.begin(), s.end());
+}
+inline std::string from_base32z(std::string_view s) {
+    return from_base32z<>(s);
+}
 
 inline namespace literals {
     inline std::string operator""_b32z(const char* x, size_t n) {
@@ -281,6 +315,6 @@ inline namespace literals {
             throw std::invalid_argument{"base32z literal is not base32z"};
         return from_base32z(in);
     }
-}
+}  // namespace literals
 
-}
+}  // namespace oxenc

--- a/oxenc/bt.h
+++ b/oxenc/bt.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "bt_value.h"
-#include "bt_serialize.h"
 #include "bt_producer.h"
+#include "bt_serialize.h"
+#include "bt_value.h"
 #include "bt_value_producer.h"

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -6,220 +6,226 @@
 #include <string_view>
 #include <unordered_map>
 #include <utility>
+
 #include "variant.h"
 
 namespace oxenc {
 
-    using namespace std::literals;
+using namespace std::literals;
 
-    class bt_dict_producer;
+class bt_dict_producer;
 
-#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
+#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+        __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
 #define OXENC_APPLE_TO_CHARS_WORKAROUND
 /// Really simplistic version of std::to_chars on Apple, because Apple doesn't allow `std::to_chars`
 /// to be used if targetting anything before macOS 10.15.  The buffer must have at least 20 chars of
 /// space (for int types up to 64-bit); we return a pointer one past the last char written.
-    template <typename IntType>
-    char* apple_to_chars10(char* buf, IntType val) {
-        static_assert(std::is_integral_v<IntType> && sizeof(IntType) <= 8);
-        if constexpr (std::is_signed_v<IntType>) {
-            if (val < 0) {
-                buf[0] = '-';
-                return apple_to_chars10(buf+1, static_cast<std::make_unsigned_t<IntType>>(-val));
-            }
+template <typename IntType>
+char* apple_to_chars10(char* buf, IntType val) {
+    static_assert(std::is_integral_v<IntType> && sizeof(IntType) <= 8);
+    if constexpr (std::is_signed_v<IntType>) {
+        if (val < 0) {
+            buf[0] = '-';
+            return apple_to_chars10(buf + 1, static_cast<std::make_unsigned_t<IntType>>(-val));
         }
-
-        // write it to the buffer in reverse (because we don't know how many chars we'll need yet, but
-        // writing in reverse will figure that out).
-        char* pos = buf;
-        do {
-            *pos++ = '0' + static_cast<char>(val % 10);
-            val /= 10;
-        } while (val > 0);
-
-        // Reverse the digits into the right order
-        int swaps = (pos - buf) / 2;
-        for (int i = 0; i < swaps; i++)
-            std::swap(buf[i], pos[-1 - i]);
-
-        return pos;
     }
-#endif
 
+    // write it to the buffer in reverse (because we don't know how many chars we'll need yet, but
+    // writing in reverse will figure that out).
+    char* pos = buf;
+    do {
+        *pos++ = '0' + static_cast<char>(val % 10);
+        val /= 10;
+    } while (val > 0);
+
+    // Reverse the digits into the right order
+    int swaps = (pos - buf) / 2;
+    for (int i = 0; i < swaps; i++)
+        std::swap(buf[i], pos[-1 - i]);
+
+    return pos;
+}
+#endif
 
 /// Class that allows you to build a bt-encoded list manually, without copying or allocating memory.
 /// This is essentially the reverse of bt_list_consumer: where it lets you stream-parse a buffer,
 /// this class lets you build directly into a buffer that you own.
 ///
 /// Out-of-buffer-space errors throw
-    class bt_list_producer {
-        friend class bt_dict_producer;
+class bt_list_producer {
+    friend class bt_dict_producer;
 
-        // Our pointers to the next write position and the past-the-end pointer of the buffer.
-        using buf_span = std::pair<char*, char*>;
-        // Our data is a begin/end pointer pair for the root list, or a pointer to our parent if a
-        // sublist.
-        std::variant<buf_span, bt_list_producer*, bt_dict_producer*> data;
-        // Reference to the write buffer; this is simply a reference to the value inside `data` for the
-        // root element, and a pointer to the root's value for sublists/subdicts.
-        buf_span& buffer;
-        // True indicates we have an open child list/dict
-        bool has_child = false;
-        // The range that contains this currently serialized value; `from` equals wherever the `l` was
-        // written that started this list and `to` is one past the `e` that ends it.  Note that `to`
-        // will always be ahead of `buf_span.first` because we always write the `e`s to close open lists
-        // but these `e`s don't advance the write position (they will be overwritten if we append).
-        const char* const from;
-        const char* to;
+    // Our pointers to the next write position and the past-the-end pointer of the buffer.
+    using buf_span = std::pair<char*, char*>;
+    // Our data is a begin/end pointer pair for the root list, or a pointer to our parent if a
+    // sublist.
+    std::variant<buf_span, bt_list_producer*, bt_dict_producer*> data;
+    // Reference to the write buffer; this is simply a reference to the value inside `data` for the
+    // root element, and a pointer to the root's value for sublists/subdicts.
+    buf_span& buffer;
+    // True indicates we have an open child list/dict
+    bool has_child = false;
+    // The range that contains this currently serialized value; `from` equals wherever the `l` was
+    // written that started this list and `to` is one past the `e` that ends it.  Note that `to`
+    // will always be ahead of `buf_span.first` because we always write the `e`s to close open lists
+    // but these `e`s don't advance the write position (they will be overwritten if we append).
+    const char* const from;
+    const char* to;
 
-        // Sublist constructors
-        bt_list_producer(bt_list_producer* parent, std::string_view prefix = "l"sv);
-        bt_list_producer(bt_dict_producer* parent, std::string_view prefix = "l"sv);
+    // Sublist constructors
+    bt_list_producer(bt_list_producer* parent, std::string_view prefix = "l"sv);
+    bt_list_producer(bt_dict_producer* parent, std::string_view prefix = "l"sv);
 
-        // Common constructor for both list and dict producer
-        bt_list_producer(char* begin, char* end, std::string_view prefix);
+    // Common constructor for both list and dict producer
+    bt_list_producer(char* begin, char* end, std::string_view prefix);
 
-        // Does the actual appending to the buffer, and throwing if we'd overrun.  If advance is false
-        // then we append without moving the buffer pointer (primarily when we append intermediate `e`s
-        // that we will overwrite if more data is added).  This means that the next write will overwrite
-        // whatever was previously written by an `advance=false` call.
-        void buffer_append(std::string_view d, bool advance = true);
+    // Does the actual appending to the buffer, and throwing if we'd overrun.  If advance is false
+    // then we append without moving the buffer pointer (primarily when we append intermediate `e`s
+    // that we will overwrite if more data is added).  This means that the next write will overwrite
+    // whatever was previously written by an `advance=false` call.
+    void buffer_append(std::string_view d, bool advance = true);
 
-        // Appends the 'e's into the buffer to close off open sublists/dicts *without* advancing the
-        // buffer position; we do this after each append so that the buffer always contains valid
-        // encoded data, even while we are still appending to it, and so that appending something raises
-        // a length_error if appending it would not leave enough space for the required e's to close the
-        // open list(s)/dict(s).
-        void append_intermediate_ends(size_t count = 1);
+    // Appends the 'e's into the buffer to close off open sublists/dicts *without* advancing the
+    // buffer position; we do this after each append so that the buffer always contains valid
+    // encoded data, even while we are still appending to it, and so that appending something raises
+    // a length_error if appending it would not leave enough space for the required e's to close the
+    // open list(s)/dict(s).
+    void append_intermediate_ends(size_t count = 1);
 
-        // Writes an integer to the given buffer; returns the one-past-the-data pointer.  Up to 20 bytes
-        // will be written and must be available in buf.  Used for both string and integer
-        // serialization.
-        template <typename IntType>
-        char* write_integer(IntType val, char* buf) {
-            static_assert(sizeof(IntType) <= 64);
+    // Writes an integer to the given buffer; returns the one-past-the-data pointer.  Up to 20 bytes
+    // will be written and must be available in buf.  Used for both string and integer
+    // serialization.
+    template <typename IntType>
+    char* write_integer(IntType val, char* buf) {
+        static_assert(sizeof(IntType) <= 64);
 
 #ifndef OXENC_APPLE_TO_CHARS_WORKAROUND
-            auto [ptr, ec] = std::to_chars(buf, buf+20, val);
-            assert(ec == std::errc());
-            return ptr;
+        auto [ptr, ec] = std::to_chars(buf, buf + 20, val);
+        assert(ec == std::errc());
+        return ptr;
 #else
-            // Hate apple.
-            return apple_to_chars10(buf, val);
+        // Hate apple.
+        return apple_to_chars10(buf, val);
 #endif
-        }
+    }
 
-        // Serializes an integer value and appends it to the output buffer.  Does not call
-        // append_intermediate_ends().
-        template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
-        void append_impl(IntType val) {
-            char buf[22]; // 'i' + base10 representation + 'e'
-            buf[0] = 'i';
-            auto* ptr = write_integer(val, buf+1);
-            *ptr++ = 'e';
-            buffer_append({buf, static_cast<size_t>(ptr-buf)});
-        }
+    // Serializes an integer value and appends it to the output buffer.  Does not call
+    // append_intermediate_ends().
+    template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+    void append_impl(IntType val) {
+        char buf[22];  // 'i' + base10 representation + 'e'
+        buf[0] = 'i';
+        auto* ptr = write_integer(val, buf + 1);
+        *ptr++ = 'e';
+        buffer_append({buf, static_cast<size_t>(ptr - buf)});
+    }
 
-        // Appends a string value, but does not call append_intermediate_ends()
-        void append_impl(std::string_view s) {
-            char buf[21]{}; // length + ':'
-            auto *ptr = write_integer(s.size(), buf);
-            *ptr++ = ':';
-            buffer_append({buf, static_cast<size_t>(ptr - buf)});
-            buffer_append(s);
-        }
+    // Appends a string value, but does not call append_intermediate_ends()
+    void append_impl(std::string_view s) {
+        char buf[21]{};  // length + ':'
+        auto* ptr = write_integer(s.size(), buf);
+        *ptr++ = ':';
+        buffer_append({buf, static_cast<size_t>(ptr - buf)});
+        buffer_append(s);
+    }
 
-    public:
-        bt_list_producer() = delete;
-        bt_list_producer(const bt_list_producer&) = delete;
-        bt_list_producer& operator=(const bt_list_producer&) = delete;
-        bt_list_producer& operator=(bt_list_producer&&) = delete;
-        bt_list_producer(bt_list_producer&& other);
+  public:
+    bt_list_producer() = delete;
+    bt_list_producer(const bt_list_producer&) = delete;
+    bt_list_producer& operator=(const bt_list_producer&) = delete;
+    bt_list_producer& operator=(bt_list_producer&&) = delete;
+    bt_list_producer(bt_list_producer&& other);
 
-        /// Constructs a list producer that writes into the range [begin, end).  If a write would go
-        /// beyond the end of the buffer an exception is raised.  Note that this will happen during
-        /// construction if the given buffer is not large enough to contain the `le` encoding of an
-        /// empty list.
-        bt_list_producer(char* begin, char* end) : bt_list_producer{begin, end, "l"sv} {}
+    /// Constructs a list producer that writes into the range [begin, end).  If a write would go
+    /// beyond the end of the buffer an exception is raised.  Note that this will happen during
+    /// construction if the given buffer is not large enough to contain the `le` encoding of an
+    /// empty list.
+    bt_list_producer(char* begin, char* end) : bt_list_producer{begin, end, "l"sv} {}
 
-        /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
-        /// go beyond the end of the buffer an exception is raised.
-        bt_list_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "l"sv} {}
+    /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
+    /// go beyond the end of the buffer an exception is raised.
+    bt_list_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "l"sv} {}
 
-        ~bt_list_producer();
+    ~bt_list_producer();
 
-        /// Returns a string_view into the currently serialized data buffer.  Note that the returned
-        /// view includes the `e` list end serialization markers which will be overwritten if the list
-        /// (or an active sublist/subdict) is appended to.
-        std::string_view view() const {
-            return {from, static_cast<size_t>(to-from)};
-        }
+    /// Returns a string_view into the currently serialized data buffer.  Note that the returned
+    /// view includes the `e` list end serialization markers which will be overwritten if the list
+    /// (or an active sublist/subdict) is appended to.
+    std::string_view view() const { return {from, static_cast<size_t>(to - from)}; }
 
-        /// Returns the end position in the buffer.
-        const char* end() const { return to; }
+    /// Returns the end position in the buffer.
+    const char* end() const { return to; }
 
-        /// Appends an element containing binary string data
-        void append(std::string_view data)
-        {
-            if (has_child) throw std::logic_error{"Cannot append to list when a sublist is active"};
-            append_impl(data);
-            append_intermediate_ends();
-        }
+    /// Appends an element containing binary string data
+    void append(std::string_view data) {
+        if (has_child)
+            throw std::logic_error{"Cannot append to list when a sublist is active"};
+        append_impl(data);
+        append_intermediate_ends();
+    }
 
-        bt_list_producer& operator+=(std::string_view data) { append(data); return *this; }
+    bt_list_producer& operator+=(std::string_view data) {
+        append(data);
+        return *this;
+    }
 
-        /// Appends an integer
-        template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
-        void append(IntType i) {
-            if (has_child) throw std::logic_error{"Cannot append to list when a sublist is active"};
-            append_impl(i);
-            append_intermediate_ends();
-        }
+    /// Appends an integer
+    template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+    void append(IntType i) {
+        if (has_child)
+            throw std::logic_error{"Cannot append to list when a sublist is active"};
+        append_impl(i);
+        append_intermediate_ends();
+    }
 
-        template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
-        bt_list_producer& operator+=(IntType i) { append(i); return *this; }
+    template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+    bt_list_producer& operator+=(IntType i) {
+        append(i);
+        return *this;
+    }
 
-        /// Appends elements from the range [from, to) to the list.  This does *not* append the elements
-        /// as a sublist: for that you should use something like: `l.append_list().append(from, to);`
-        template <typename ForwardIt>
-        void append(ForwardIt from, ForwardIt to) {
-            if (has_child) throw std::logic_error{"Cannot append to list when a sublist is active"};
-            while (from != to)
-                append_impl(*from++);
-            append_intermediate_ends();
-        }
+    /// Appends elements from the range [from, to) to the list.  This does *not* append the elements
+    /// as a sublist: for that you should use something like: `l.append_list().append(from, to);`
+    template <typename ForwardIt>
+    void append(ForwardIt from, ForwardIt to) {
+        if (has_child)
+            throw std::logic_error{"Cannot append to list when a sublist is active"};
+        while (from != to)
+            append_impl(*from++);
+        append_intermediate_ends();
+    }
 
-        /// Appends a sublist to this list.  Returns a new bt_list_producer that references the parent
-        /// list.  The parent cannot be added to until the sublist is destroyed.  This is meant to be
-        /// used via RAII:
-        ///
-        ///     buf data[16];
-        ///     bt_list_producer list{data, sizeof(data)};
-        ///     {
-        ///         auto sublist = list.append_list();
-        ///         sublist.append(42);
-        ///     }
-        ///     list.append(1);
-        ///     // `data` now contains: `lli42eei1ee`
-        ///
-        /// If doing more complex lifetime management, take care not to allow the child instance to
-        /// outlive the parent.
-        bt_list_producer append_list();
+    /// Appends a sublist to this list.  Returns a new bt_list_producer that references the parent
+    /// list.  The parent cannot be added to until the sublist is destroyed.  This is meant to be
+    /// used via RAII:
+    ///
+    ///     buf data[16];
+    ///     bt_list_producer list{data, sizeof(data)};
+    ///     {
+    ///         auto sublist = list.append_list();
+    ///         sublist.append(42);
+    ///     }
+    ///     list.append(1);
+    ///     // `data` now contains: `lli42eei1ee`
+    ///
+    /// If doing more complex lifetime management, take care not to allow the child instance to
+    /// outlive the parent.
+    bt_list_producer append_list();
 
-        /// Appends a dict to this list.  Returns a new bt_dict_producer that references the parent
-        /// list.  The parent cannot be added to until the subdict is destroyed.  This is meant to be
-        /// used via RAII (see append_list() for details).
-        ///
-        /// If doing more complex lifetime management, take care not to allow the child instance to
-        /// outlive the parent.
-        bt_dict_producer append_dict();
+    /// Appends a dict to this list.  Returns a new bt_dict_producer that references the parent
+    /// list.  The parent cannot be added to until the subdict is destroyed.  This is meant to be
+    /// used via RAII (see append_list() for details).
+    ///
+    /// If doing more complex lifetime management, take care not to allow the child instance to
+    /// outlive the parent.
+    bt_dict_producer append_dict();
 
-        /// Appends a bt_value, bt_dict, or bt_list to this bt_list.  You must include the
-        /// bt_value_producer.h header (either directly or via bt.h) to use this method.
-        template <typename T>
-        void append_bt(const T& bt);
-    };
-
+    /// Appends a bt_value, bt_dict, or bt_list to this bt_list.  You must include the
+    /// bt_value_producer.h header (either directly or via bt.h) to use this method.
+    template <typename T>
+    void append_bt(const T& bt);
+};
 
 /// Class that allows you to build a bt-encoded dict manually, without copying or allocating memory.
 /// This is essentially the reverse of bt_dict_consumer: where it lets you stream-parse a buffer,
@@ -227,157 +233,173 @@ namespace oxenc {
 ///
 /// Note that bt-encoded dicts *must* be produced in (ASCII) ascending key order, but that this is
 /// only tracked/enforced for non-release builds (i.e. without -DNDEBUG).
-    class bt_dict_producer : bt_list_producer {
-        friend class bt_list_producer;
+class bt_dict_producer : bt_list_producer {
+    friend class bt_list_producer;
 
-        // Subdict constructors
+    // Subdict constructors
 
-        bt_dict_producer(bt_list_producer* parent) : bt_list_producer{parent, "d"sv} {}
-        bt_dict_producer(bt_dict_producer* parent) : bt_list_producer{parent, "d"sv} {}
+    bt_dict_producer(bt_list_producer* parent) : bt_list_producer{parent, "d"sv} {}
+    bt_dict_producer(bt_dict_producer* parent) : bt_list_producer{parent, "d"sv} {}
 
-        // Checks a just-written key string to make sure it is monotonically increasing from the last
-        // key.  Does nothing in a release build.
+    // Checks a just-written key string to make sure it is monotonically increasing from the last
+    // key.  Does nothing in a release build.
 #ifdef NDEBUG
-        constexpr void check_incrementing_key(size_t) const {}
+    constexpr void check_incrementing_key(size_t) const {}
 #else
-        // String view into the buffer where we wrote the previous key.
-        std::string_view last_key;
-        void check_incrementing_key(size_t size) {
-            std::string_view this_key{buffer.first - size, size};
-            assert(!last_key.data() || this_key > last_key);
-            last_key = this_key;
-        }
+    // String view into the buffer where we wrote the previous key.
+    std::string_view last_key;
+    void check_incrementing_key(size_t size) {
+        std::string_view this_key{buffer.first - size, size};
+        assert(!last_key.data() || this_key > last_key);
+        last_key = this_key;
+    }
 #endif
 
-    public:
-        /// Constructs a dict producer that writes into the range [begin, end).  If a write would go
-        /// beyond the end of the buffer an exception is raised.  Note that this will happen during
-        /// construction if the given buffer is not large enough to contain the `de` encoding of an
-        /// empty list.
-        bt_dict_producer(char* begin, char* end) : bt_list_producer{begin, end, "d"sv} {}
+  public:
+    /// Constructs a dict producer that writes into the range [begin, end).  If a write would go
+    /// beyond the end of the buffer an exception is raised.  Note that this will happen during
+    /// construction if the given buffer is not large enough to contain the `de` encoding of an
+    /// empty list.
+    bt_dict_producer(char* begin, char* end) : bt_list_producer{begin, end, "d"sv} {}
 
-        /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
-        /// go beyond the end of the buffer an exception is raised.
-        bt_dict_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "d"sv} {}
+    /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
+    /// go beyond the end of the buffer an exception is raised.
+    bt_dict_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "d"sv} {}
 
-        /// Returns a string_view into the currently serialized data buffer.  Note that the returned
-        /// view includes the `e` dict end serialization markers which will be overwritten if the dict
-        /// (or an active sublist/subdict) is appended to.
-        std::string_view view() const { return bt_list_producer::view(); }
+    /// Returns a string_view into the currently serialized data buffer.  Note that the returned
+    /// view includes the `e` dict end serialization markers which will be overwritten if the dict
+    /// (or an active sublist/subdict) is appended to.
+    std::string_view view() const { return bt_list_producer::view(); }
 
-        /// Returns the end position in the buffer.
-        const char* end() const { return bt_list_producer::end(); }
+    /// Returns the end position in the buffer.
+    const char* end() const { return bt_list_producer::end(); }
 
-        /// Appends a key-value pair with a string or integer value.  The key must be > the last key
-        /// added, but this is only enforced (with an assertion) in debug builds.
-        template <typename T, std::enable_if_t<std::is_convertible_v<T, std::string_view> || std::is_integral_v<T>, int> = 0>
-        void append(std::string_view key, const T& value) {
-            if (has_child) throw std::logic_error{"Cannot append to list when a sublist is active"};
-            append_impl(key);
-            check_incrementing_key(key.size());
-            append_impl(value);
-            append_intermediate_ends();
-        }
-
-        /// Appends pairs from the range [from, to) to the dict.  Elements must have a .first
-        /// convertible to a string_view, and a .second that is either string view convertible or an
-        /// integer.  This does *not* append the elements as a subdict: for that you should use
-        /// something like: `l.append_dict().append(key, from, to);`
-        ///
-        /// Also note that the range *must* be sorted by keys, which means either using an ordered
-        /// container (e.g. std::map) or a manually ordered container (such as a vector or list of
-        /// pairs).  unordered_map, however, is not acceptable.
-        template <typename ForwardIt, std::enable_if_t<!std::is_convertible_v<ForwardIt, std::string_view>, int> = 0>
-        void append(ForwardIt from, ForwardIt to) {
-            if (has_child) throw std::logic_error{"Cannot append to list when a sublist is active"};
-            using KeyType = std::remove_cv_t<std::decay_t<decltype(from->first)>>;
-            using ValType = std::decay_t<decltype(from->second)>;
-            static_assert(std::is_convertible_v<decltype(from->first), std::string_view>);
-            static_assert(std::is_convertible_v<ValType, std::string_view> || std::is_integral_v<ValType>);
-            using BadUnorderedMap = std::unordered_map<KeyType, ValType>;
-            static_assert(!( // Disallow unordered_map iterators because they are not going to be ordered.
-                              std::is_same_v<typename BadUnorderedMap::iterator, ForwardIt> ||
-                              std::is_same_v<typename BadUnorderedMap::const_iterator, ForwardIt>));
-            while (from != to) {
-                const auto& [k, v] = *from++;
-                append_impl(k);
-                check_incrementing_key(k.size());
-                append_impl(v);
-            }
-            append_intermediate_ends();
-        }
-
-        /// Appends a sub-dict value to this dict with the given key.  Returns a new bt_dict_producer
-        /// that references the parent dict.  The parent cannot be added to until the subdict is
-        /// destroyed.  Key must be (ascii-comparison) larger than the previous key.
-        ///
-        /// This is meant to be used via RAII:
-        ///
-        ///     buf data[32];
-        ///     bt_dict_producer dict{data, sizeof(data)};
-        ///     {
-        ///         auto subdict = dict.begin_dict("myKey");
-        ///         subdict.append("x", 42);
-        ///     }
-        ///     dict.append("y", "");
-        ///     // `data` now contains: `d5:myKeyd1:xi42ee1:y0:e`
-        ///
-        /// If doing more complex lifetime management, take care not to allow the child instance to
-        /// outlive the parent.
-        bt_dict_producer append_dict(std::string_view key) {
-            if (has_child) throw std::logic_error{"Cannot call append_dict while another nested list/dict is active"};
-            append_impl(key);
-            check_incrementing_key(key.size());
-            return bt_dict_producer{this};
-        }
-
-        /// Appends a list to this dict with the given key (which must be ascii-larger than the previous
-        /// key).  Returns a new bt_list_producer that references the parent dict.  The parent cannot be
-        /// added to until the sublist is destroyed.
-        ///
-        /// This is meant to be used via RAII (see append_dict() for details).
-        ///
-        /// If doing more complex lifetime management, take care not to allow the child instance to
-        /// outlive the parent.
-        bt_list_producer append_list(std::string_view key)
-        {
-            if (has_child) throw std::logic_error{"Cannot call append_list while another nested list/dict is active"};
-            append_impl(key);
-            check_incrementing_key(key.size());
-            return bt_list_producer{this};
-        }
-
-        /// Appends a bt_value, bt_dict, or bt_list to this bt_dict.  You must include the
-        /// bt_value_producer.h header (either directly or via bt.h) to use this method.
-        template <typename T>
-        void append_bt(std::string_view key, const T& bt);
-    };
-
-    inline bt_list_producer::bt_list_producer(bt_list_producer* parent, std::string_view prefix)
-        : data{parent}, buffer{parent->buffer}, from{buffer.first} {
-        parent->has_child = true;
-        buffer_append(prefix);
+    /// Appends a key-value pair with a string or integer value.  The key must be > the last key
+    /// added, but this is only enforced (with an assertion) in debug builds.
+    template <
+            typename T,
+            std::enable_if_t<
+                    std::is_convertible_v<T, std::string_view> || std::is_integral_v<T>,
+                    int> = 0>
+    void append(std::string_view key, const T& value) {
+        if (has_child)
+            throw std::logic_error{"Cannot append to list when a sublist is active"};
+        append_impl(key);
+        check_incrementing_key(key.size());
+        append_impl(value);
         append_intermediate_ends();
     }
 
-    inline bt_list_producer::bt_list_producer(bt_dict_producer* parent, std::string_view prefix)
-        : data{parent}, buffer{parent->buffer}, from{buffer.first} {
-        parent->has_child = true;
-        buffer_append(prefix);
+    /// Appends pairs from the range [from, to) to the dict.  Elements must have a .first
+    /// convertible to a string_view, and a .second that is either string view convertible or an
+    /// integer.  This does *not* append the elements as a subdict: for that you should use
+    /// something like: `l.append_dict().append(key, from, to);`
+    ///
+    /// Also note that the range *must* be sorted by keys, which means either using an ordered
+    /// container (e.g. std::map) or a manually ordered container (such as a vector or list of
+    /// pairs).  unordered_map, however, is not acceptable.
+    template <
+            typename ForwardIt,
+            std::enable_if_t<!std::is_convertible_v<ForwardIt, std::string_view>, int> = 0>
+    void append(ForwardIt from, ForwardIt to) {
+        if (has_child)
+            throw std::logic_error{"Cannot append to list when a sublist is active"};
+        using KeyType = std::remove_cv_t<std::decay_t<decltype(from->first)>>;
+        using ValType = std::decay_t<decltype(from->second)>;
+        static_assert(std::is_convertible_v<decltype(from->first), std::string_view>);
+        static_assert(
+                std::is_convertible_v<ValType, std::string_view> || std::is_integral_v<ValType>);
+        using BadUnorderedMap = std::unordered_map<KeyType, ValType>;
+        static_assert(
+                !(  // Disallow unordered_map iterators because they are not going to be ordered.
+                        std::is_same_v<typename BadUnorderedMap::iterator, ForwardIt> ||
+                        std::is_same_v<typename BadUnorderedMap::const_iterator, ForwardIt>));
+        while (from != to) {
+            const auto& [k, v] = *from++;
+            append_impl(k);
+            check_incrementing_key(k.size());
+            append_impl(v);
+        }
         append_intermediate_ends();
     }
 
-    inline bt_list_producer::bt_list_producer(bt_list_producer&& other)
-        : data{std::move(other.data)}, buffer{other.buffer}, from{other.from}, to{other.to} {
-        if (other.has_child) throw std::logic_error{"Cannot move bt_list/dict_producer with active sublists/subdicts"};
-        var::visit([](auto& x) {
-            if constexpr (!std::is_same_v<buf_span&, decltype(x)>)
-                             x = nullptr;
-        }, other.data);
+    /// Appends a sub-dict value to this dict with the given key.  Returns a new bt_dict_producer
+    /// that references the parent dict.  The parent cannot be added to until the subdict is
+    /// destroyed.  Key must be (ascii-comparison) larger than the previous key.
+    ///
+    /// This is meant to be used via RAII:
+    ///
+    ///     buf data[32];
+    ///     bt_dict_producer dict{data, sizeof(data)};
+    ///     {
+    ///         auto subdict = dict.begin_dict("myKey");
+    ///         subdict.append("x", 42);
+    ///     }
+    ///     dict.append("y", "");
+    ///     // `data` now contains: `d5:myKeyd1:xi42ee1:y0:e`
+    ///
+    /// If doing more complex lifetime management, take care not to allow the child instance to
+    /// outlive the parent.
+    bt_dict_producer append_dict(std::string_view key) {
+        if (has_child)
+            throw std::logic_error{
+                    "Cannot call append_dict while another nested list/dict is active"};
+        append_impl(key);
+        check_incrementing_key(key.size());
+        return bt_dict_producer{this};
     }
 
-    inline void bt_list_producer::buffer_append(std::string_view d, bool advance) {
-        var::visit(
+    /// Appends a list to this dict with the given key (which must be ascii-larger than the previous
+    /// key).  Returns a new bt_list_producer that references the parent dict.  The parent cannot be
+    /// added to until the sublist is destroyed.
+    ///
+    /// This is meant to be used via RAII (see append_dict() for details).
+    ///
+    /// If doing more complex lifetime management, take care not to allow the child instance to
+    /// outlive the parent.
+    bt_list_producer append_list(std::string_view key) {
+        if (has_child)
+            throw std::logic_error{
+                    "Cannot call append_list while another nested list/dict is active"};
+        append_impl(key);
+        check_incrementing_key(key.size());
+        return bt_list_producer{this};
+    }
+
+    /// Appends a bt_value, bt_dict, or bt_list to this bt_dict.  You must include the
+    /// bt_value_producer.h header (either directly or via bt.h) to use this method.
+    template <typename T>
+    void append_bt(std::string_view key, const T& bt);
+};
+
+inline bt_list_producer::bt_list_producer(bt_list_producer* parent, std::string_view prefix) :
+        data{parent}, buffer{parent->buffer}, from{buffer.first} {
+    parent->has_child = true;
+    buffer_append(prefix);
+    append_intermediate_ends();
+}
+
+inline bt_list_producer::bt_list_producer(bt_dict_producer* parent, std::string_view prefix) :
+        data{parent}, buffer{parent->buffer}, from{buffer.first} {
+    parent->has_child = true;
+    buffer_append(prefix);
+    append_intermediate_ends();
+}
+
+inline bt_list_producer::bt_list_producer(bt_list_producer&& other) :
+        data{std::move(other.data)}, buffer{other.buffer}, from{other.from}, to{other.to} {
+    if (other.has_child)
+        throw std::logic_error{"Cannot move bt_list/dict_producer with active sublists/subdicts"};
+    var::visit(
+            [](auto& x) {
+                if constexpr (!std::is_same_v<buf_span&, decltype(x)>)
+                    x = nullptr;
+            },
+            other.data);
+}
+
+inline void bt_list_producer::buffer_append(std::string_view d, bool advance) {
+    var::visit(
             [d, advance, this](auto& x) {
                 if constexpr (std::is_same_v<buf_span&, decltype(x)>) {
                     size_t avail = std::distance(x.first, x.second);
@@ -392,25 +414,27 @@ namespace oxenc {
                 }
             },
             data);
-    }
+}
 
-    inline void bt_list_producer::append_intermediate_ends(size_t count) {
-        static constexpr std::string_view eee = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"sv;
-        return var::visit([this, count](auto& x) mutable {
-            if constexpr (std::is_same_v<buf_span&, decltype(x)>) {
-                for (; count > eee.size(); count -= eee.size())
-                    buffer_append(eee, false);
-                buffer_append(eee.substr(0, count), false);
-            } else {
-                // x is a parent pointer
-                x->append_intermediate_ends(count + 1);
-                to = x->to - 1; // Our `to` should be one 'e' before our parent's `to`.
-            }
-        }, data);
-    }
+inline void bt_list_producer::append_intermediate_ends(size_t count) {
+    static constexpr std::string_view eee = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"sv;
+    return var::visit(
+            [this, count](auto& x) mutable {
+                if constexpr (std::is_same_v<buf_span&, decltype(x)>) {
+                    for (; count > eee.size(); count -= eee.size())
+                        buffer_append(eee, false);
+                    buffer_append(eee.substr(0, count), false);
+                } else {
+                    // x is a parent pointer
+                    x->append_intermediate_ends(count + 1);
+                    to = x->to - 1;  // Our `to` should be one 'e' before our parent's `to`.
+                }
+            },
+            data);
+}
 
-    inline bt_list_producer::~bt_list_producer() {
-        var::visit(
+inline bt_list_producer::~bt_list_producer() {
+    var::visit(
             [this](auto& x) {
                 if constexpr (!std::is_same_v<buf_span&, decltype(x)>) {
                     if (!x)
@@ -424,22 +448,24 @@ namespace oxenc {
                 }
             },
             data);
-    }
+}
 
-    inline bt_list_producer::bt_list_producer(char* begin, char* end, std::string_view prefix)
-        : data{buf_span{begin, end}}, buffer{*std::get_if<buf_span>(&data)}, from{buffer.first} {
-        buffer_append(prefix);
-        append_intermediate_ends();
-    }
+inline bt_list_producer::bt_list_producer(char* begin, char* end, std::string_view prefix) :
+        data{buf_span{begin, end}}, buffer{*std::get_if<buf_span>(&data)}, from{buffer.first} {
+    buffer_append(prefix);
+    append_intermediate_ends();
+}
 
-    inline bt_list_producer bt_list_producer::append_list() {
-        if (has_child) throw std::logic_error{"Cannot call append_list while another nested list/dict is active"};
-        return bt_list_producer{this};
-    }
+inline bt_list_producer bt_list_producer::append_list() {
+    if (has_child)
+        throw std::logic_error{"Cannot call append_list while another nested list/dict is active"};
+    return bt_list_producer{this};
+}
 
-    inline bt_dict_producer bt_list_producer::append_dict() {
-        if (has_child) throw std::logic_error{"Cannot call append_dict while another nested list/dict is active"};
-        return bt_dict_producer{this};
-    }
+inline bt_dict_producer bt_list_producer::append_dict() {
+    if (has_child)
+        throw std::logic_error{"Cannot call append_dict while another nested list/dict is active"};
+    return bt_dict_producer{this};
+}
 
-} // namespace oxenc
+}  // namespace oxenc

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -4,6 +4,7 @@
 #include <charconv>
 #include <stdexcept>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -48,50 +49,66 @@ char* apple_to_chars10(char* buf, IntType val) {
 }
 #endif
 
-/// Class that allows you to build a bt-encoded list manually, without copying or allocating memory.
-/// This is essentially the reverse of bt_list_consumer: where it lets you stream-parse a buffer,
-/// this class lets you build directly into a buffer that you own.
+/// Class that allows you to build a bt-encoded list manually, optionally without copying or
+/// allocating memory.  This is essentially the reverse of bt_list_consumer: where it lets you
+/// stream-parse a buffer, this class lets you build directly into a buffer.
 ///
-/// Out-of-buffer-space errors throw
+/// Out-of-buffer-space errors throw std::length_error when using an external buffer.
 class bt_list_producer {
     friend class bt_dict_producer;
 
-    // Our pointers to the next write position and the past-the-end pointer of the buffer.
-    using buf_span = std::pair<char*, char*>;
-    // Our data is a begin/end pointer pair for the root list, or a pointer to our parent if a
-    // sublist.
-    std::variant<buf_span, bt_list_producer*, bt_dict_producer*> data;
-    // Reference to the write buffer; this is simply a reference to the value inside `data` for the
+    // For external buffer mode we keep pointers to the start position and past-the-end positions.
+    struct buf_span {
+        char* const init;
+        char* const end;
+    };
+
+    // Our output type: either external buffer pointers, or a string that we build:
+    using output = std::variant<std::string, buf_span>;
+
+    // Our data for the root list is either a begin/end pointer pair or a string; for
+    // sublists it is a pointer to the parent list/dict.
+    std::variant<output, bt_list_producer*, bt_dict_producer*> data;
+
+    // Reference to the output; this is simply a reference to the value inside `data` for the
     // root element, and a pointer to the root's value for sublists/subdicts.
-    buf_span& buffer;
+    output& out;
+
     // True indicates we have an open child list/dict
     bool has_child = false;
-    // The range that contains this currently serialized value; `from` equals wherever the `l` was
-    // written that started this list and `to` is one past the `e` that ends it.  Note that `to`
-    // will always be ahead of `buf_span.first` because we always write the `e`s to close open lists
-    // but these `e`s don't advance the write position (they will be overwritten if we append).
-    const char* const from;
-    const char* to;
+
+    // If we have a dict or list parent, this returns a pointer it (for a dict, static cast to
+    // the base bt_list_producer type).  nullptr if no parent.
+    bt_list_producer* parent();
+
+    // The range that contains this currently serialized value; `from` is the offset (relative
+    // to the beginning of the buffer, or beginning of the string) wherever the `l` was written
+    // that started this list; `next` is the offset where the next value goes (which will always
+    // have a closing `e` in it, to close the list; the `e` gets overwrite upon appending
+    // another element).
+    const size_t from;
+    size_t next{from};
 
     // Sublist constructors
-    bt_list_producer(bt_list_producer* parent, std::string_view prefix = "l"sv);
-    bt_list_producer(bt_dict_producer* parent, std::string_view prefix = "l"sv);
+    explicit bt_list_producer(bt_list_producer* parent, char prefix = 'l');
+    explicit bt_list_producer(bt_dict_producer* parent, char prefix = 'l');
 
-    // Common constructor for both list and dict producer
-    bt_list_producer(char* begin, char* end, std::string_view prefix);
+    // Internal common constructor for both list and dict producer for external buffer mode.
+    bt_list_producer(char* begin, char* end, char prefix);
 
-    // Does the actual appending to the buffer, and throwing if we'd overrun.  If advance is false
-    // then we append without moving the buffer pointer (primarily when we append intermediate `e`s
-    // that we will overwrite if more data is added).  This means that the next write will overwrite
-    // whatever was previously written by an `advance=false` call.
-    void buffer_append(std::string_view d, bool advance = true);
+    // Internal common constructor for both list and dict producer for expandable std::string
+    // buffer mode.
+    explicit bt_list_producer(char prefix, size_t reserve);
+
+    // Does the actual appending to the buffer, and throwing if we'd overrun.
+    void buffer_append(std::string_view d);
 
     // Appends the 'e's into the buffer to close off open sublists/dicts *without* advancing the
     // buffer position; we do this after each append so that the buffer always contains valid
     // encoded data, even while we are still appending to it, and so that appending something raises
     // a length_error if appending it would not leave enough space for the required e's to close the
     // open list(s)/dict(s).
-    void append_intermediate_ends(size_t count = 1);
+    void append_intermediate_ends();
 
     // Writes an integer to the given buffer; returns the one-past-the-data pointer.  Up to 20 bytes
     // will be written and must be available in buf.  Used for both string and integer
@@ -123,7 +140,7 @@ class bt_list_producer {
 
     // Appends a string value, but does not call append_intermediate_ends()
     void append_impl(std::string_view s) {
-        char buf[21]{};  // length + ':'
+        char buf[21];  // length + ':'
         auto* ptr = write_integer(s.size(), buf);
         *ptr++ = ':';
         buffer_append({buf, static_cast<size_t>(ptr - buf)});
@@ -131,7 +148,6 @@ class bt_list_producer {
     }
 
   public:
-    bt_list_producer() = delete;
     bt_list_producer(const bt_list_producer&) = delete;
     bt_list_producer& operator=(const bt_list_producer&) = delete;
     bt_list_producer& operator=(bt_list_producer&&) = delete;
@@ -141,21 +157,59 @@ class bt_list_producer {
     /// beyond the end of the buffer an exception is raised.  Note that this will happen during
     /// construction if the given buffer is not large enough to contain the `le` encoding of an
     /// empty list.
-    bt_list_producer(char* begin, char* end) : bt_list_producer{begin, end, "l"sv} {}
+    bt_list_producer(char* begin, char* end) : bt_list_producer{begin, end, 'l'} {}
 
     /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
     /// go beyond the end of the buffer an exception is raised.
-    bt_list_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "l"sv} {}
+    bt_list_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, 'l'} {}
+
+    /// Constructs a list producer that writes to an internal, expandable string.  `reserve` can
+    /// be passed a non-zero value to reserve an initial size in the std::string.
+    explicit bt_list_producer(size_t reserve = 0) : bt_list_producer{'l', reserve} {}
 
     ~bt_list_producer();
 
     /// Returns a string_view into the currently serialized data buffer.  Note that the returned
     /// view includes the `e` list end serialization markers which will be overwritten if the list
     /// (or an active sublist/subdict) is appended to.
-    std::string_view view() const { return {from, static_cast<size_t>(to - from)}; }
+    std::string_view view() const {
+        if (auto* s = std::get_if<std::string>(&out))
+            return std::string_view{*s}.substr(from, next - from + 1);
+        auto& b = var::get<buf_span>(out);
+        return {b.init + from, static_cast<size_t>(next - from + 1)};
+    }
 
-    /// Returns the end position in the buffer.
-    const char* end() const { return to; }
+    /// Extracts the string, when not using buffer mode.  This is only usable on the root
+    /// list/dict producer, and may only be used in rvalue context, as it destroys the internal
+    /// buffer, such as: std::move(producer).str().  Throws logic_error if called on a
+    /// sublist/subdict, or on a external buffer producer.
+    ///
+    /// (If you just want a copy of the string, use `view()` instead).
+    std::string str() && {
+        if (parent())
+            throw std::logic_error{"Cannot call bt_producer .str() on a sublist/subdict"};
+        auto* s = std::get_if<std::string>(&out);
+        if (!s)
+            throw std::logic_error{"Cannot call bt_producer .str() when using an external buffer"};
+
+        std::string ret;
+        ret.swap(*s);
+        // Leave behind an empty producer
+        *s += ret[0];
+        *s += 'e';
+        next = 1;
+        return ret;
+    }
+
+    /// Returns the end position in the buffer.  (This is primarily useful for external buffer
+    /// mode, but still works in string mode).
+    const char* end() const {
+        if (auto* s = std::get_if<std::string>(&out))
+            return s->data() + next + 1;
+        auto* bs = std::get_if<buf_span>(&out);
+        assert(bs);
+        return bs->init + next + 1;
+    }
 
     /// Appends an element containing binary string data
     void append(std::string_view data) {
@@ -238,19 +292,18 @@ class bt_dict_producer : bt_list_producer {
 
     // Subdict constructors
 
-    bt_dict_producer(bt_list_producer* parent) : bt_list_producer{parent, "d"sv} {}
-    bt_dict_producer(bt_dict_producer* parent) : bt_list_producer{parent, "d"sv} {}
+    bt_dict_producer(bt_list_producer* parent) : bt_list_producer{parent, 'd'} {}
+    bt_dict_producer(bt_dict_producer* parent) : bt_list_producer{parent, 'd'} {}
 
     // Checks a just-written key string to make sure it is monotonically increasing from the last
-    // key.  Does nothing in a release build.
+    // key.  Does nothing in a release build.  (The string is outside the defines because otherwise
+    // we'd have a ODR violation between debug and non-debug builds).
+    std::string last_key;
 #ifdef NDEBUG
-    constexpr void check_incrementing_key(size_t) const {}
+    constexpr void check_incrementing_key(std::string_view) const {}
 #else
-    // String view into the buffer where we wrote the previous key.
-    std::string_view last_key;
-    void check_incrementing_key(size_t size) {
-        std::string_view this_key{buffer.first - size, size};
-        assert(!last_key.data() || this_key > last_key);
+    void check_incrementing_key(std::string_view this_key) {
+        assert(last_key.empty() || this_key > last_key);
         last_key = this_key;
     }
 #endif
@@ -260,19 +313,40 @@ class bt_dict_producer : bt_list_producer {
     /// beyond the end of the buffer an exception is raised.  Note that this will happen during
     /// construction if the given buffer is not large enough to contain the `de` encoding of an
     /// empty list.
-    bt_dict_producer(char* begin, char* end) : bt_list_producer{begin, end, "d"sv} {}
+    bt_dict_producer(char* begin, char* end) : bt_list_producer{begin, end, 'd'} {}
 
-    /// Constructs a list producer that writes into the range [begin, begin+size).  If a write would
+    /// Constructs a dict producer that writes into the range [begin, begin+size).  If a write would
     /// go beyond the end of the buffer an exception is raised.
-    bt_dict_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, "d"sv} {}
+    bt_dict_producer(char* begin, size_t len) : bt_list_producer{begin, begin + len, 'd'} {}
+
+    /// Constructs a dict producer that writes to an internal, expandable string.  `reserve` can
+    /// be passed a non-zero value to reserve an initial size in the std::string.
+    explicit bt_dict_producer(size_t reserve = 0) : bt_list_producer{'d', reserve} {}
 
     /// Returns a string_view into the currently serialized data buffer.  Note that the returned
     /// view includes the `e` dict end serialization markers which will be overwritten if the dict
     /// (or an active sublist/subdict) is appended to.
-    std::string_view view() const { return bt_list_producer::view(); }
+    std::string_view view() const {
+        return bt_list_producer::view();
+    }
+
+    /// Extracts the string, when not using buffer mode.  This is only usable on the root
+    /// list/dict producer, and may only be used in rvalue context, as it destroys the internal
+    /// buffer, such as: std::move(producer).str().  Throws logic_error if called on a
+    /// sublist/subdict, or on a external buffer producer.
+    ///
+    /// (If you just want a copy of the string, use `view()` instead).
+    std::string str() && {
+#ifndef NDEBUG
+        last_key = {};
+#endif
+        return std::move(*this).bt_list_producer::str();
+    }
 
     /// Returns the end position in the buffer.
-    const char* end() const { return bt_list_producer::end(); }
+    const char* end() const {
+        return bt_list_producer::end();
+    }
 
     /// Appends a key-value pair with a string or integer value.  The key must be > the last key
     /// added, but this is only enforced (with an assertion) in debug builds.
@@ -284,8 +358,8 @@ class bt_dict_producer : bt_list_producer {
     void append(std::string_view key, const T& value) {
         if (has_child)
             throw std::logic_error{"Cannot append to list when a sublist is active"};
+        check_incrementing_key(key);
         append_impl(key);
-        check_incrementing_key(key.size());
         append_impl(value);
         append_intermediate_ends();
     }
@@ -316,8 +390,8 @@ class bt_dict_producer : bt_list_producer {
                         std::is_same_v<typename BadUnorderedMap::const_iterator, ForwardIt>));
         while (from != to) {
             const auto& [k, v] = *from++;
+            check_incrementing_key(k);
             append_impl(k);
-            check_incrementing_key(k.size());
             append_impl(v);
         }
         append_intermediate_ends();
@@ -344,8 +418,8 @@ class bt_dict_producer : bt_list_producer {
         if (has_child)
             throw std::logic_error{
                     "Cannot call append_dict while another nested list/dict is active"};
+        check_incrementing_key(key);
         append_impl(key);
-        check_incrementing_key(key.size());
         return bt_dict_producer{this};
     }
 
@@ -361,8 +435,8 @@ class bt_dict_producer : bt_list_producer {
         if (has_child)
             throw std::logic_error{
                     "Cannot call append_list while another nested list/dict is active"};
+        check_incrementing_key(key);
         append_impl(key);
-        check_incrementing_key(key.size());
         return bt_list_producer{this};
     }
 
@@ -372,87 +446,94 @@ class bt_dict_producer : bt_list_producer {
     void append_bt(std::string_view key, const T& bt);
 };
 
-inline bt_list_producer::bt_list_producer(bt_list_producer* parent, std::string_view prefix) :
-        data{parent}, buffer{parent->buffer}, from{buffer.first} {
+inline bt_list_producer::bt_list_producer(bt_list_producer* parent, char prefix) :
+        data{parent}, out{parent->out}, from{parent->next} {
     parent->has_child = true;
-    buffer_append(prefix);
+    buffer_append(std::string_view{&prefix, 1});
     append_intermediate_ends();
+    for (; parent; parent = parent->parent())
+        parent->next++;
 }
 
-inline bt_list_producer::bt_list_producer(bt_dict_producer* parent, std::string_view prefix) :
-        data{parent}, buffer{parent->buffer}, from{buffer.first} {
-    parent->has_child = true;
-    buffer_append(prefix);
-    append_intermediate_ends();
+inline bt_list_producer::bt_list_producer(bt_dict_producer* parent, char prefix) :
+        bt_list_producer{static_cast<bt_list_producer*>(parent), prefix} {
+    data = parent;
 }
 
 inline bt_list_producer::bt_list_producer(bt_list_producer&& other) :
-        data{std::move(other.data)}, buffer{other.buffer}, from{other.from}, to{other.to} {
+        data{std::move(other.data)}, out{other.out}, from{other.from}, next{other.next} {
     if (other.has_child)
         throw std::logic_error{"Cannot move bt_list/dict_producer with active sublists/subdicts"};
     var::visit(
             [](auto& x) {
-                if constexpr (!std::is_same_v<buf_span&, decltype(x)>)
+                if constexpr (!std::is_same_v<output&, decltype(x)>)
                     x = nullptr;
             },
             other.data);
 }
 
-inline void bt_list_producer::buffer_append(std::string_view d, bool advance) {
-    var::visit(
-            [d, advance, this](auto& x) {
-                if constexpr (std::is_same_v<buf_span&, decltype(x)>) {
-                    size_t avail = std::distance(x.first, x.second);
-                    if (d.size() > avail)
-                        throw std::length_error{"Cannot write bt_producer: buffer size exceeded"};
-                    std::copy(d.begin(), d.end(), x.first);
-                    to = x.first + d.size();
-                    if (advance)
-                        x.first += d.size();
-                } else {
-                    x->buffer_append(d, advance);
-                }
-            },
-            data);
+inline bt_list_producer* bt_list_producer::parent() {
+    if (auto* parent = std::get_if<bt_list_producer*>(&data))
+        return *parent;
+    if (auto* parent = std::get_if<bt_dict_producer*>(&data))
+        return static_cast<bt_list_producer*>(*parent);
+    return nullptr;
 }
 
-inline void bt_list_producer::append_intermediate_ends(size_t count) {
-    static constexpr std::string_view eee = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"sv;
-    return var::visit(
-            [this, count](auto& x) mutable {
-                if constexpr (std::is_same_v<buf_span&, decltype(x)>) {
-                    for (; count > eee.size(); count -= eee.size())
-                        buffer_append(eee, false);
-                    buffer_append(eee.substr(0, count), false);
-                } else {
-                    // x is a parent pointer
-                    x->append_intermediate_ends(count + 1);
-                    to = x->to - 1;  // Our `to` should be one 'e' before our parent's `to`.
-                }
-            },
-            data);
+inline void bt_list_producer::buffer_append(std::string_view d) {
+    if (auto* s = std::get_if<std::string>(&out)) {
+        s->resize(next);  // Truncate any trailing e's
+        s->append(d);
+    } else {
+        auto* bs = std::get_if<buf_span>(&out);
+        assert(bs);
+        size_t avail = std::distance(bs->init + next, bs->end);
+        if (d.size() > avail)
+            throw std::length_error{"Cannot write bt_producer: buffer size exceeded"};
+        std::copy(d.begin(), d.end(), bs->init + next);
+    }
+    for (auto* p = this; p; p = p->parent())
+        p->next += d.size();
+}
+
+inline void bt_list_producer::append_intermediate_ends() {
+    size_t count = 0;
+    for (auto* p = this; p; p = p->parent())
+        count++;
+
+    if (auto* s = std::get_if<std::string>(&out))
+        s->append(count, 'e');
+    else {
+        auto* bs = std::get_if<buf_span>(&out);
+        assert(bs);
+        auto* begin = bs->init + next;
+        auto* end = begin + count;
+        if (end > bs->end)
+            throw std::length_error{"Cannot write bt_producer: buffer size exceeded"};
+        std::fill(begin, end, 'e');
+    }
 }
 
 inline bt_list_producer::~bt_list_producer() {
-    var::visit(
-            [this](auto& x) {
-                if constexpr (!std::is_same_v<buf_span&, decltype(x)>) {
-                    if (!x)
-                        return;
-                    assert(!has_child);
-                    assert(x->has_child);
-                    x->has_child = false;
-                    // We've already written the intermediate 'e', so just increment
-                    // the buffer to finalize it.
-                    buffer.first++;
-                }
-            },
-            data);
+    auto* p = parent();
+    if (!p)
+        return;
+    assert(!has_child);
+    assert(p->has_child);
+    p->has_child = false;
 }
 
-inline bt_list_producer::bt_list_producer(char* begin, char* end, std::string_view prefix) :
-        data{buf_span{begin, end}}, buffer{*std::get_if<buf_span>(&data)}, from{buffer.first} {
-    buffer_append(prefix);
+inline bt_list_producer::bt_list_producer(char* begin, char* end, char prefix) :
+        data{buf_span{begin, end}}, out{*std::get_if<output>(&data)}, from{0}, next{0} {
+    buffer_append(std::string_view{&prefix, 1});
+    append_intermediate_ends();
+}
+
+inline bt_list_producer::bt_list_producer(char prefix, size_t reserve) :
+        data{std::string{}}, out{*std::get_if<output>(&data)}, from{0}, next{0} {
+    if (reserve > 0)
+        std::get_if<std::string>(&out)->reserve(reserve);
+    buffer_append(std::string_view{&prefix, 1});
     append_intermediate_ends();
 }
 

--- a/oxenc/bt_value.h
+++ b/oxenc/bt_value.h
@@ -3,33 +3,27 @@
 // This header is here to provide just the basic bt_value/bt_dict/bt_list definitions without
 // needing to include the full bt_serialize.h header.
 
-#include <map>
-#include <list>
 #include <cstdint>
-#include <variant>
+#include <list>
+#include <map>
 #include <string>
 #include <string_view>
+#include <variant>
 
 namespace oxenc {
 
 struct bt_value;
 
 /// The type used to store dictionaries inside bt_value.
-using bt_dict = std::map<std::string, bt_value>; // NB: unordered_map doesn't work because it can't be used with a predeclared type
+using bt_dict = std::map<std::string, bt_value>;  // NB: unordered_map doesn't work because it can't
+                                                  // be used with a predeclared type
 /// The type used to store list items inside bt_value.
 using bt_list = std::list<bt_value>;
 
 /// The basic variant that can hold anything (recursively).
-using bt_variant = std::variant<
-    std::string,
-    std::string_view,
-    int64_t,
-    uint64_t,
-    bt_list,
-    bt_dict
->;
+using bt_variant = std::variant<std::string, std::string_view, int64_t, uint64_t, bt_list, bt_dict>;
 
-#ifdef __cpp_lib_remove_cvref // C++20
+#ifdef __cpp_lib_remove_cvref  // C++20
 using std::remove_cvref_t;
 #else
 template <typename T>
@@ -39,7 +33,8 @@ using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 template <typename T, typename Variant>
 struct has_alternative;
 template <typename T, typename... V>
-struct has_alternative<T, std::variant<V...>> : std::bool_constant<(std::is_same_v<T, V> || ...)> {};
+struct has_alternative<T, std::variant<V...>> : std::bool_constant<(std::is_same_v<T, V> || ...)> {
+};
 template <typename T, typename Variant>
 constexpr bool has_alternative_v = has_alternative<T, Variant>::value;
 
@@ -48,10 +43,13 @@ namespace detail {
     bt_list tuple_to_list(const Tuple& tuple, std::index_sequence<Is...>) {
         return {{bt_value{std::get<Is>(tuple)}...}};
     }
-    template <typename T> constexpr bool is_tuple = false;
-    template <typename... T> constexpr bool is_tuple<std::tuple<T...>> = true;
-    template <typename S, typename T> constexpr bool is_tuple<std::pair<S, T>> = true;
-}
+    template <typename T>
+    constexpr bool is_tuple = false;
+    template <typename... T>
+    constexpr bool is_tuple<std::tuple<T...>> = true;
+    template <typename S, typename T>
+    constexpr bool is_tuple<std::pair<S, T>> = true;
+}  // namespace detail
 
 /// Recursive generic type that can fully represent everything valid for a BT serialization.
 /// This is basically just an empty wrapper around the std::variant, except we add some extra
@@ -63,22 +61,33 @@ struct bt_value : bt_variant {
     using bt_variant::bt_variant;
     using bt_variant::operator=;
 
-    template <typename T, typename U = std::remove_reference_t<T>, std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
+    template <
+            typename T,
+            typename U = std::remove_reference_t<T>,
+            std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
     bt_value(T&& uint) : bt_variant{static_cast<uint64_t>(uint)} {}
 
-    template <typename T, typename U = std::remove_reference_t<T>, std::enable_if_t<std::is_integral_v<U> && std::is_signed_v<U>, int> = 0>
+    template <
+            typename T,
+            typename U = std::remove_reference_t<T>,
+            std::enable_if_t<std::is_integral_v<U> && std::is_signed_v<U>, int> = 0>
     bt_value(T&& sint) : bt_variant{static_cast<int64_t>(sint)} {}
 
     template <typename... T>
-    bt_value(const std::tuple<T...>& tuple) : bt_variant{detail::tuple_to_list(tuple, std::index_sequence_for<T...>{})} {}
+    bt_value(const std::tuple<T...>& tuple) :
+            bt_variant{detail::tuple_to_list(tuple, std::index_sequence_for<T...>{})} {}
 
     template <typename S, typename T>
-    bt_value(const std::pair<S, T>& pair) : bt_variant{detail::tuple_to_list(pair, std::index_sequence_for<S, T>{})} {}
+    bt_value(const std::pair<S, T>& pair) :
+            bt_variant{detail::tuple_to_list(pair, std::index_sequence_for<S, T>{})} {}
 
-    template <typename T, typename U = std::remove_reference_t<T>, std::enable_if_t<!std::is_integral_v<U> && !detail::is_tuple<U>, int> = 0>
+    template <
+            typename T,
+            typename U = std::remove_reference_t<T>,
+            std::enable_if_t<!std::is_integral_v<U> && !detail::is_tuple<U>, int> = 0>
     bt_value(T&& v) : bt_variant{std::forward<T>(v)} {}
 
     bt_value(const char* s) : bt_value{std::string_view{s}} {}
 };
 
-}
+}  // namespace oxenc

--- a/oxenc/bt_value_producer.h
+++ b/oxenc/bt_value_producer.h
@@ -1,99 +1,98 @@
+#include <type_traits>
+
 #include "bt_producer.h"
 #include "bt_value.h"
 #include "variant.h"
-#include <type_traits>
 
 /// This header provides the implementations of append_bt(bt_value/bt_list/bt_dict) for
 /// bt_serialize.  (It is optional to avoid unnecessary includes when not wanted).
 
 namespace oxenc {
 
-    namespace detail {
+namespace detail {
 
-        void serialize_list(bt_list_producer& out, const bt_list& l);
-        void serialize_dict(bt_dict_producer& out, const bt_dict& l);
+    void serialize_list(bt_list_producer& out, const bt_list& l);
+    void serialize_dict(bt_dict_producer& out, const bt_dict& l);
 
-        struct dict_appender {
-            bt_dict_producer& out;
-            std::string_view key;
-            dict_appender(bt_dict_producer& out, std::string_view key)
-                : out{out}, key{key} {}
+    struct dict_appender {
+        bt_dict_producer& out;
+        std::string_view key;
+        dict_appender(bt_dict_producer& out, std::string_view key) : out{out}, key{key} {}
 
-            void operator()(const bt_dict& d) {
-                auto subdict = out.append_dict(key);
-                serialize_dict(subdict, d);
-            }
-            void operator()(const bt_list& l) {
-                auto sublist = out.append_list(key);
-                serialize_list(sublist, l);
-            }
-            template <typename T>
-            void operator()(const T& other) {
-                out.append(key, other);
-            }
-        };
-
-        struct list_appender {
-            bt_list_producer& out;
-            explicit list_appender(bt_list_producer& out)
-                : out{out} {}
-
-            void operator()(const bt_dict& d) {
-                auto subdict = out.append_dict();
-                serialize_dict(subdict, d);
-            }
-            void operator()(const bt_list& l) {
-                auto sublist = out.append_list();
-                serialize_list(sublist, l);
-            }
-            template <typename T>
-            void operator()(const T& other) {
-                out.append(other);
-            }
-        };
-
-        inline void serialize_dict(bt_dict_producer& out, const bt_dict& d) {
-            for (const auto& [k, v]: d)
-                var::visit(dict_appender{out, k}, static_cast<const bt_variant&>(v));
+        void operator()(const bt_dict& d) {
+            auto subdict = out.append_dict(key);
+            serialize_dict(subdict, d);
         }
-
-        inline void serialize_list(bt_list_producer& out, const bt_list& l) {
-            for (auto& val : l)
-                var::visit(list_appender{out}, static_cast<const bt_variant&>(val));
+        void operator()(const bt_list& l) {
+            auto sublist = out.append_list(key);
+            serialize_list(sublist, l);
         }
+        template <typename T>
+        void operator()(const T& other) {
+            out.append(key, other);
+        }
+    };
+
+    struct list_appender {
+        bt_list_producer& out;
+        explicit list_appender(bt_list_producer& out) : out{out} {}
+
+        void operator()(const bt_dict& d) {
+            auto subdict = out.append_dict();
+            serialize_dict(subdict, d);
+        }
+        void operator()(const bt_list& l) {
+            auto sublist = out.append_list();
+            serialize_list(sublist, l);
+        }
+        template <typename T>
+        void operator()(const T& other) {
+            out.append(other);
+        }
+    };
+
+    inline void serialize_dict(bt_dict_producer& out, const bt_dict& d) {
+        for (const auto& [k, v] : d)
+            var::visit(dict_appender{out, k}, static_cast<const bt_variant&>(v));
     }
 
-    template <>
-    inline void bt_list_producer::append_bt(const bt_dict& bt) {
-        auto subdict = append_dict();
-        detail::serialize_dict(subdict, bt);
+    inline void serialize_list(bt_list_producer& out, const bt_list& l) {
+        for (auto& val : l)
+            var::visit(list_appender{out}, static_cast<const bt_variant&>(val));
     }
+}  // namespace detail
 
-    template <>
-    inline void bt_list_producer::append_bt(const bt_list& bt) {
-        auto sublist = append_list();
-        detail::serialize_list(sublist, bt);
-    }
-
-    template <>
-    inline void bt_list_producer::append_bt(const bt_value& bt) {
-        var::visit(detail::list_appender{*this}, static_cast<const bt_variant&>(bt));
-    }
-
-    template <>
-    inline void bt_dict_producer::append_bt(std::string_view key, const bt_dict& bt) {
-        auto subdict = append_dict(key);
-        detail::serialize_dict(subdict, bt);
-    }
-
-    template <>
-    inline void bt_dict_producer::append_bt(std::string_view key, const bt_list& bt) {
-        auto sublist = append_list(key);
-        detail::serialize_list(sublist, bt);
-    }
-
-    template <>
-    inline void bt_dict_producer::append_bt(std::string_view key, const bt_value& bt) {
-        var::visit(detail::dict_appender{*this, key}, static_cast<const bt_variant&>(bt));
-    }
+template <>
+inline void bt_list_producer::append_bt(const bt_dict& bt) {
+    auto subdict = append_dict();
+    detail::serialize_dict(subdict, bt);
 }
+
+template <>
+inline void bt_list_producer::append_bt(const bt_list& bt) {
+    auto sublist = append_list();
+    detail::serialize_list(sublist, bt);
+}
+
+template <>
+inline void bt_list_producer::append_bt(const bt_value& bt) {
+    var::visit(detail::list_appender{*this}, static_cast<const bt_variant&>(bt));
+}
+
+template <>
+inline void bt_dict_producer::append_bt(std::string_view key, const bt_dict& bt) {
+    auto subdict = append_dict(key);
+    detail::serialize_dict(subdict, bt);
+}
+
+template <>
+inline void bt_dict_producer::append_bt(std::string_view key, const bt_list& bt) {
+    auto sublist = append_list(key);
+    detail::serialize_list(sublist, bt);
+}
+
+template <>
+inline void bt_dict_producer::append_bt(std::string_view key, const bt_value& bt) {
+    var::visit(detail::dict_appender{*this, key}, static_cast<const bt_variant&>(bt));
+}
+}  // namespace oxenc

--- a/oxenc/byte_type.h
+++ b/oxenc/byte_type.h
@@ -10,19 +10,25 @@ namespace oxenc::detail {
 
 // Fallback - we just try a char
 template <typename OutputIt, typename = void>
-struct byte_type { using type = char; };
+struct byte_type {
+    using type = char;
+};
 
 // Support for things like std::back_inserter:
 template <typename OutputIt>
 struct byte_type<OutputIt, std::void_t<typename OutputIt::container_type>> {
-    using type = typename OutputIt::container_type::value_type; };
+    using type = typename OutputIt::container_type::value_type;
+};
 
 // iterator, raw pointers:
 template <typename OutputIt>
-struct byte_type<OutputIt, std::enable_if_t<std::is_reference_v<typename std::iterator_traits<OutputIt>::reference>>> {
-    using type = std::remove_reference_t<typename std::iterator_traits<OutputIt>::reference>; };
+struct byte_type<
+        OutputIt,
+        std::enable_if_t<std::is_reference_v<typename std::iterator_traits<OutputIt>::reference>>> {
+    using type = std::remove_reference_t<typename std::iterator_traits<OutputIt>::reference>;
+};
 
 template <typename OutputIt>
 using byte_type_t = typename byte_type<OutputIt>::type;
 
-}
+}  // namespace oxenc::detail

--- a/oxenc/endian.h
+++ b/oxenc/endian.h
@@ -5,200 +5,203 @@
 #include <type_traits>
 
 #if defined(_MSC_VER) && (!defined(__clang__) || defined(__c2__))
-#  include <cstdlib>
+#include <cstdlib>
 
-#  define bswap_16(x) _byteswap_ushort(x)
-#  define bswap_32(x) _byteswap_ulong(x)
-#  define bswap_64(x) _byteswap_uint64(x)
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
 #elif defined(__clang__) || defined(__GNUC__)
-#  define bswap_16(x) __builtin_bswap16(x)
-#  define bswap_32(x) __builtin_bswap32(x)
-#  define bswap_64(x) __builtin_bswap64(x)
+#define bswap_16(x) __builtin_bswap16(x)
+#define bswap_32(x) __builtin_bswap32(x)
+#define bswap_64(x) __builtin_bswap64(x)
 #elif defined(__linux__)
 extern "C" {
-#  include <byteswap.h>
-} // extern "C"
+#include <byteswap.h>
+}  // extern "C"
 #else
-#  error "Don't know how to byteswap on this platform!"
+#error "Don't know how to byteswap on this platform!"
 #endif
 
 namespace oxenc {
 
-    /// True if this is a little-endian platform
-    inline constexpr bool little_endian =
+/// True if this is a little-endian platform
+inline constexpr bool little_endian =
 #if defined(__LITTLE_ENDIAN__)
         true
 #elif defined(__BIG_ENDIAN__)
         false
 #elif defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN
         true
-#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+        __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
         true
 #elif defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN
         false
-#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+        __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         false
 #elif defined(_WIN32)
         true
 #else
-#  error "Error: don't know which endian this is"
+#error "Error: don't know which endian this is"
 #endif
         ;
 
-    /// True if this is a big-endian platform
-    inline constexpr bool big_endian = !little_endian;
+/// True if this is a big-endian platform
+inline constexpr bool big_endian = !little_endian;
 
-    /// True if the type is integral and of a size we support swapping.  (We also allow size-1
-    /// values to be passed here for completeness, though nothing is ever swapped for such a value).
-    template <typename T> constexpr bool is_endian_swappable =
-        std::is_integral_v<T> && (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
+/// True if the type is integral and of a size we support swapping.  (We also allow size-1
+/// values to be passed here for completeness, though nothing is ever swapped for such a value).
+template <typename T>
+constexpr bool is_endian_swappable = std::is_integral_v<T> && (sizeof(T) == 1 || sizeof(T) == 2 ||
+                                                               sizeof(T) == 4 || sizeof(T) == 8);
 
-    /// Byte swaps an integer value unconditionally.  You usually want to use one of the other
-    /// endian-aware functions rather than this.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void byteswap_inplace(T& val) {
-        if constexpr (sizeof(T) == 2)
-            val = bswap_16(val);
-        else if constexpr (sizeof(T) == 4)
-            val = bswap_32(val);
-        else if constexpr (sizeof(T) == 8)
-            val = bswap_64(val);
-    }
+/// Byte swaps an integer value unconditionally.  You usually want to use one of the other
+/// endian-aware functions rather than this.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void byteswap_inplace(T& val) {
+    if constexpr (sizeof(T) == 2)
+        val = bswap_16(val);
+    else if constexpr (sizeof(T) == 4)
+        val = bswap_32(val);
+    else if constexpr (sizeof(T) == 8)
+        val = bswap_64(val);
+}
 
-    /// Converts a host-order integer value into a little-endian value, mutating it.  Does nothing
-    /// on little-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void host_to_little_inplace(T& val) {
-        if constexpr (!little_endian)
-            byteswap_inplace(val);
-    }
+/// Converts a host-order integer value into a little-endian value, mutating it.  Does nothing
+/// on little-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void host_to_little_inplace(T& val) {
+    if constexpr (!little_endian)
+        byteswap_inplace(val);
+}
 
-    /// Converts a host-order integer value into a little-endian value, returning it.  Does no
-    /// converstion on little-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T host_to_little(T val) {
-        host_to_little_inplace(val);
-        return val;
-    }
+/// Converts a host-order integer value into a little-endian value, returning it.  Does no
+/// converstion on little-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T host_to_little(T val) {
+    host_to_little_inplace(val);
+    return val;
+}
 
-    /// Converts a little-endian integer value into a host-order (native) integer value, mutating
-    /// it.  Does nothing on little-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void little_to_host_inplace(T& val) {
-        if constexpr (!little_endian)
-            byteswap_inplace(val);
-    }
+/// Converts a little-endian integer value into a host-order (native) integer value, mutating
+/// it.  Does nothing on little-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void little_to_host_inplace(T& val) {
+    if constexpr (!little_endian)
+        byteswap_inplace(val);
+}
 
-    /// Converts a little-order integer value into a host-order (native) integer value, returning
-    /// it.  Does no conversion on little-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T little_to_host(T val) {
-        little_to_host_inplace(val);
-        return val;
-    }
+/// Converts a little-order integer value into a host-order (native) integer value, returning
+/// it.  Does no conversion on little-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T little_to_host(T val) {
+    little_to_host_inplace(val);
+    return val;
+}
 
-    /// Converts a host-order integer value into a big-endian value, mutating it.  Does nothing on
-    /// big-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void host_to_big_inplace(T& val) {
-        if constexpr (!big_endian)
-            byteswap_inplace(val);
-    }
+/// Converts a host-order integer value into a big-endian value, mutating it.  Does nothing on
+/// big-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void host_to_big_inplace(T& val) {
+    if constexpr (!big_endian)
+        byteswap_inplace(val);
+}
 
-    /// Converts a host-order integer value into a big-endian value, returning it.  Does no
-    /// conversion on big-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T host_to_big(T val) {
-        host_to_big_inplace(val);
-        return val;
-    }
+/// Converts a host-order integer value into a big-endian value, returning it.  Does no
+/// conversion on big-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T host_to_big(T val) {
+    host_to_big_inplace(val);
+    return val;
+}
 
-    /// Converts a big-endian value into a host-order (native) integer value, mutating it.  Does
-    /// nothing on big-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void big_to_host_inplace(T& val) {
-        if constexpr (!big_endian)
-            byteswap_inplace(val);
-    }
+/// Converts a big-endian value into a host-order (native) integer value, mutating it.  Does
+/// nothing on big-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void big_to_host_inplace(T& val) {
+    if constexpr (!big_endian)
+        byteswap_inplace(val);
+}
 
-    /// Converts a big-order integer value into a host-order (native) integer value, returning it.
-    /// Does no conversion on big-endian platforms.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T big_to_host(T val) {
-        big_to_host_inplace(val);
-        return val;
-    }
+/// Converts a big-order integer value into a host-order (native) integer value, returning it.
+/// Does no conversion on big-endian platforms.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T big_to_host(T val) {
+    big_to_host_inplace(val);
+    return val;
+}
 
-    /// Loads a host-order integer value from a memory location containing little-endian bytes.
-    /// (There is no alignment requirement on the given pointer address).
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T load_little_to_host(const void* from) {
-        T val;
-        std::memcpy(&val, from, sizeof(T));
-        little_to_host_inplace(val);
-        return val;
-    }
+/// Loads a host-order integer value from a memory location containing little-endian bytes.
+/// (There is no alignment requirement on the given pointer address).
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T load_little_to_host(const void* from) {
+    T val;
+    std::memcpy(&val, from, sizeof(T));
+    little_to_host_inplace(val);
+    return val;
+}
 
-    /// Loads a little-endian integer value from a memory location containing host order bytes.
-    /// (There is no alignment requirement on the given pointer address).
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T load_host_to_little(const void* from) {
-        T val;
-        std::memcpy(&val, from, sizeof(T));
-        host_to_little_inplace(val);
-        return val;
-    }
+/// Loads a little-endian integer value from a memory location containing host order bytes.
+/// (There is no alignment requirement on the given pointer address).
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T load_host_to_little(const void* from) {
+    T val;
+    std::memcpy(&val, from, sizeof(T));
+    host_to_little_inplace(val);
+    return val;
+}
 
-    /// Loads a host-order integer value from a memory location containing big-endian bytes.  (There
-    /// is no alignment requirement on the given pointer address).
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T load_big_to_host(const void* from) {
-        T val;
-        std::memcpy(&val, from, sizeof(T));
-        big_to_host_inplace(val);
-        return val;
-    }
+/// Loads a host-order integer value from a memory location containing big-endian bytes.  (There
+/// is no alignment requirement on the given pointer address).
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T load_big_to_host(const void* from) {
+    T val;
+    std::memcpy(&val, from, sizeof(T));
+    big_to_host_inplace(val);
+    return val;
+}
 
-    /// Loads a big-endian integer value from a memory location containing host order bytes.  (There
-    /// is no alignment requirement on the given pointer address).
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    T load_host_to_big(const void* from) {
-        T val;
-        std::memcpy(&val, from, sizeof(T));
-        host_to_big_inplace(val);
-        return val;
-    }
+/// Loads a big-endian integer value from a memory location containing host order bytes.  (There
+/// is no alignment requirement on the given pointer address).
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+T load_host_to_big(const void* from) {
+    T val;
+    std::memcpy(&val, from, sizeof(T));
+    host_to_big_inplace(val);
+    return val;
+}
 
-    /// Writes a little-endian integer value into the given memory location, copying and converting
-    /// it (if necessary) from the given host-order integer value.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void write_host_as_little(T val, void* to) {
-        host_to_little_inplace(val);
-        std::memcpy(to, &val, sizeof(T));
-    }
+/// Writes a little-endian integer value into the given memory location, copying and converting
+/// it (if necessary) from the given host-order integer value.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void write_host_as_little(T val, void* to) {
+    host_to_little_inplace(val);
+    std::memcpy(to, &val, sizeof(T));
+}
 
-    /// Writes a big-endian integer value into the given memory location, copying and converting it
-    /// (if necessary) from the given host-order integer value.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void write_host_as_big(T val, void* to) {
-        host_to_big_inplace(val);
-        std::memcpy(to, &val, sizeof(T));
-    }
+/// Writes a big-endian integer value into the given memory location, copying and converting it
+/// (if necessary) from the given host-order integer value.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void write_host_as_big(T val, void* to) {
+    host_to_big_inplace(val);
+    std::memcpy(to, &val, sizeof(T));
+}
 
-    /// Writes a host-order integer value into the given memory location, copying and converting it
-    /// (if necessary) from the given little-endian integer value.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void write_little_as_host(T val, void* to) {
-        little_to_host_inplace(val);
-        std::memcpy(to, &val, sizeof(T));
-    }
+/// Writes a host-order integer value into the given memory location, copying and converting it
+/// (if necessary) from the given little-endian integer value.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void write_little_as_host(T val, void* to) {
+    little_to_host_inplace(val);
+    std::memcpy(to, &val, sizeof(T));
+}
 
-    /// Writes a host-order integer value into the given memory location, copying and converting it
-    /// (if necessary) from the given big-endian integer value.
-    template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
-    void write_big_as_host(T val, void* to) {
-        big_to_host_inplace(val);
-        std::memcpy(to, &val, sizeof(T));
-    }
+/// Writes a host-order integer value into the given memory location, copying and converting it
+/// (if necessary) from the given big-endian integer value.
+template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+void write_big_as_host(T val, void* to) {
+    big_to_host_inplace(val);
+    std::memcpy(to, &val, sizeof(T));
+}
 
-} // namespace oxenc
+}  // namespace oxenc

--- a/oxenc/hex.h
+++ b/oxenc/hex.h
@@ -1,56 +1,65 @@
 #pragma once
+#include <array>
+#include <cassert>
+#include <iterator>
+#include <stdexcept>
 #include <string>
 #include <string_view>
-#include <array>
-#include <iterator>
-#include <cassert>
-#include <stdexcept>
+
 #include "byte_type.h"
 
 namespace oxenc {
 
 namespace detail {
 
-/// Compile-time generated lookup tables hex conversion
-struct hex_table {
-    char from_hex_lut[256];
-    char to_hex_lut[16];
-    constexpr hex_table() noexcept : from_hex_lut{}, to_hex_lut{} {
-        for (unsigned char c = 0; c < 10; c++) {
-            from_hex_lut[(unsigned char)('0' + c)] =  0  + c;
-            to_hex_lut[  (unsigned char)( 0  + c)] = '0' + c;
+    /// Compile-time generated lookup tables hex conversion
+    struct hex_table {
+        char from_hex_lut[256];
+        char to_hex_lut[16];
+        constexpr hex_table() noexcept : from_hex_lut{}, to_hex_lut{} {
+            for (unsigned char c = 0; c < 10; c++) {
+                from_hex_lut[(unsigned char)('0' + c)] = 0 + c;
+                to_hex_lut[(unsigned char)(0 + c)] = '0' + c;
+            }
+            for (unsigned char c = 0; c < 6; c++) {
+                from_hex_lut[(unsigned char)('a' + c)] = 10 + c;
+                from_hex_lut[(unsigned char)('A' + c)] = 10 + c;
+                to_hex_lut[(unsigned char)(10 + c)] = 'a' + c;
+            }
         }
-        for (unsigned char c = 0; c < 6; c++) {
-            from_hex_lut[(unsigned char)('a' + c)] = 10  + c;
-            from_hex_lut[(unsigned char)('A' + c)] = 10  + c;
-            to_hex_lut[  (unsigned char)(10  + c)] = 'a' + c;
-        }
-    }
-    constexpr char from_hex(unsigned char c) const noexcept { return from_hex_lut[c]; }
-    constexpr char to_hex(unsigned char b) const noexcept { return to_hex_lut[b]; }
-};
-inline constexpr hex_table hex_lut{};
+        constexpr char from_hex(unsigned char c) const noexcept { return from_hex_lut[c]; }
+        constexpr char to_hex(unsigned char b) const noexcept { return to_hex_lut[b]; }
+    };
+    inline constexpr hex_table hex_lut{};
 
-// This main point of this static assert is to force the compiler to compile-time build the constexpr tables.
-static_assert(hex_lut.from_hex('a') == 10 && hex_lut.from_hex('F') == 15 && hex_lut.to_hex(13) == 'd', "");
+    // This main point of this static assert is to force the compiler to compile-time build the
+    // constexpr tables.
+    static_assert(
+            hex_lut.from_hex('a') == 10 && hex_lut.from_hex('F') == 15 && hex_lut.to_hex(13) == 'd',
+            "");
 
-} // namespace detail
+}  // namespace detail
 
 /// Returns the number of characters required to encode a hex string from the given number of bytes.
-inline constexpr size_t to_hex_size(size_t byte_size) { return byte_size * 2; }
+inline constexpr size_t to_hex_size(size_t byte_size) {
+    return byte_size * 2;
+}
 /// Returns the number of bytes required to decode a hex string of the given size.
-inline constexpr size_t from_hex_size(size_t hex_size) { return hex_size / 2; }
+inline constexpr size_t from_hex_size(size_t hex_size) {
+    return hex_size / 2;
+}
 
 /// Iterable object for on-the-fly hex encoding.  Used internally, but also particularly useful when
 /// converting from one encoding to another.
 template <typename InputIt>
 struct hex_encoder final {
-private:
+  private:
     InputIt _it, _end;
     static_assert(sizeof(decltype(*_it)) == 1, "hex_encoder requires chars/bytes input iterator");
     uint8_t c = 0;
     bool second_half = false;
-public:
+
+  public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = char;
@@ -69,11 +78,14 @@ public:
             ++_it;
         return *this;
     }
-    hex_encoder operator++(int) { hex_encoder copy{*this}; ++*this; return copy; }
+    hex_encoder operator++(int) {
+        hex_encoder copy{*this};
+        ++*this;
+        return copy;
+    }
     char operator*() {
-        return detail::hex_lut.to_hex(second_half
-                ? c & 0x0f
-                : (c = static_cast<uint8_t>(*_it)) >> 4);
+        return detail::hex_lut.to_hex(
+                second_half ? c & 0x0f : (c = static_cast<uint8_t>(*_it)) >> 4);
     }
 };
 
@@ -91,7 +103,9 @@ OutputIt to_hex(InputIt begin, InputIt end, OutputIt out) {
 template <typename It>
 std::string to_hex(It begin, It end) {
     std::string hex;
-    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<It>::iterator_category>) {
+    if constexpr (std::is_base_of_v<
+                          std::random_access_iterator_tag,
+                          typename std::iterator_traits<It>::iterator_category>) {
         using std::distance;
         hex.reserve(to_hex_size(distance(begin, end)));
     }
@@ -101,14 +115,19 @@ std::string to_hex(It begin, It end) {
 
 /// Creates a hex string from an iterable, std::string-like object
 template <typename CharT>
-std::string to_hex(std::basic_string_view<CharT> s) { return to_hex(s.begin(), s.end()); }
-inline std::string to_hex(std::string_view s) { return to_hex<>(s); }
+std::string to_hex(std::basic_string_view<CharT> s) {
+    return to_hex(s.begin(), s.end());
+}
+inline std::string to_hex(std::string_view s) {
+    return to_hex<>(s);
+}
 
 /// Returns true if the given value is a valid hex digit.
 template <typename CharT>
 constexpr bool is_hex_digit(CharT c) {
     static_assert(sizeof(CharT) == 1, "is_hex requires chars/bytes");
-    return detail::hex_lut.from_hex(static_cast<unsigned char>(c)) != 0 || static_cast<unsigned char>(c) == '0';
+    return detail::hex_lut.from_hex(static_cast<unsigned char>(c)) != 0 ||
+           static_cast<unsigned char>(c) == '0';
 }
 
 /// Returns true if all elements in the range are hex characters *and* the string length is a
@@ -116,7 +135,9 @@ constexpr bool is_hex_digit(CharT c) {
 template <typename It>
 constexpr bool is_hex(It begin, It end) {
     static_assert(sizeof(decltype(*begin)) == 1, "is_hex requires chars/bytes");
-    constexpr bool ra = std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<It>::iterator_category>;
+    constexpr bool ra = std::is_base_of_v<
+            std::random_access_iterator_tag,
+            typename std::iterator_traits<It>::iterator_category>;
     if constexpr (ra) {
         using std::distance;
         if (distance(begin, end) % 2 != 0)
@@ -125,7 +146,8 @@ constexpr bool is_hex(It begin, It end) {
 
     size_t count = 0;
     for (; begin != end; ++begin) {
-        if constexpr (!ra) ++count;
+        if constexpr (!ra)
+            ++count;
         if (!is_hex_digit(*begin))
             return false;
     }
@@ -136,8 +158,12 @@ constexpr bool is_hex(It begin, It end) {
 
 /// Returns true if all elements in the string-like value are hex characters
 template <typename CharT>
-constexpr bool is_hex(std::basic_string_view<CharT> s) { return is_hex(s.begin(), s.end()); }
-constexpr bool is_hex(std::string_view s) { return is_hex(s.begin(), s.end()); }
+constexpr bool is_hex(std::basic_string_view<CharT> s) {
+    return is_hex(s.begin(), s.end());
+}
+constexpr bool is_hex(std::string_view s) {
+    return is_hex(s.begin(), s.end());
+}
 
 /// Convert a hex digit into its numeric (0-15) value
 constexpr char from_hex_digit(unsigned char x) noexcept {
@@ -145,18 +171,21 @@ constexpr char from_hex_digit(unsigned char x) noexcept {
 }
 
 /// Constructs a byte value from a pair of hex digits
-constexpr char from_hex_pair(unsigned char a, unsigned char b) noexcept { return (from_hex_digit(a) << 4) | from_hex_digit(b); }
+constexpr char from_hex_pair(unsigned char a, unsigned char b) noexcept {
+    return (from_hex_digit(a) << 4) | from_hex_digit(b);
+}
 
 /// Iterable object for on-the-fly hex decoding.  Used internally but also particularly useful when
 /// converting from one encoding to another.  Undefined behaviour if the given iterator range is not
 /// a valid hex string with even length (i.e. is_hex() should return true).
 template <typename InputIt>
 struct hex_decoder final {
-private:
+  private:
     InputIt _it, _end;
     static_assert(sizeof(decltype(*_it)) == 1, "hex_encoder requires chars/bytes input iterator");
     char byte;
-public:
+
+  public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = char;
@@ -177,16 +206,19 @@ public:
             load_byte();
         return *this;
     }
-    hex_decoder operator++(int) { hex_decoder copy{*this}; ++*this; return copy; }
+    hex_decoder operator++(int) {
+        hex_decoder copy{*this};
+        ++*this;
+        return copy;
+    }
     char operator*() const { return byte; }
 
-private:
+  private:
     void load_byte() {
         auto a = *_it;
         auto b = *++_it;
         byte = from_hex_pair(static_cast<unsigned char>(a), static_cast<unsigned char>(b));
     }
-
 };
 
 /// Converts a sequence of hex digits to bytes.  Undefined behaviour if any characters are not in
@@ -209,7 +241,9 @@ OutputIt from_hex(InputIt begin, InputIt end, OutputIt out) {
 template <typename It>
 std::string from_hex(It begin, It end) {
     std::string bytes;
-    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<It>::iterator_category>) {
+    if constexpr (std::is_base_of_v<
+                          std::random_access_iterator_tag,
+                          typename std::iterator_traits<It>::iterator_category>) {
         using std::distance;
         bytes.reserve(from_hex_size(distance(begin, end)));
     }
@@ -220,8 +254,12 @@ std::string from_hex(It begin, It end) {
 /// Converts hex digits from a std::string-like object into a std::string of bytes.  Undefined
 /// behaviour if any characters are not in [0-9a-fA-F] or if the input sequence length is not even.
 template <typename CharT>
-std::string from_hex(std::basic_string_view<CharT> s) { return from_hex(s.begin(), s.end()); }
-inline std::string from_hex(std::string_view s) { return from_hex<>(s); }
+std::string from_hex(std::basic_string_view<CharT> s) {
+    return from_hex(s.begin(), s.end());
+}
+inline std::string from_hex(std::string_view s) {
+    return from_hex<>(s);
+}
 
 inline namespace literals {
     inline std::string operator""_hex(const char* x, size_t n) {
@@ -230,6 +268,6 @@ inline namespace literals {
             throw std::invalid_argument{"hex literal is not hex"};
         return from_hex(in);
     }
-}
+}  // namespace literals
 
-}
+}  // namespace oxenc

--- a/oxenc/variant.h
+++ b/oxenc/variant.h
@@ -14,15 +14,15 @@
 #include <variant>
 
 #ifdef __APPLE__
-#  include <AvailabilityMacros.h>
-#  if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 101400)
-#    define BROKEN_APPLE_VARIANT
-#  endif
+#include <AvailabilityMacros.h>
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 101400)
+#define BROKEN_APPLE_VARIANT
+#endif
 #endif
 
 #ifndef BROKEN_APPLE_VARIANT
 
-namespace var = std; // Oh look, actual C++17 support
+namespace var = std;  // Oh look, actual C++17 support
 
 #else
 
@@ -38,42 +38,50 @@ namespace var {
 // to the std:: implementation.
 template <typename T, typename... Types>
 constexpr T& get(std::variant<Types...>& var) {
-    if (auto* v = std::get_if<T>(&var)) return *v;
+    if (auto* v = std::get_if<T>(&var))
+        return *v;
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <typename T, typename... Types>
 constexpr const T& get(const std::variant<Types...>& var) {
-    if (auto* v = std::get_if<T>(&var)) return *v;
+    if (auto* v = std::get_if<T>(&var))
+        return *v;
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <typename T, typename... Types>
 constexpr const T&& get(const std::variant<Types...>&& var) {
-    if (auto* v = std::get_if<T>(&var)) return std::move(*v);
+    if (auto* v = std::get_if<T>(&var))
+        return std::move(*v);
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <typename T, typename... Types>
 constexpr T&& get(std::variant<Types...>&& var) {
-    if (auto* v = std::get_if<T>(&var)) return std::move(*v);
+    if (auto* v = std::get_if<T>(&var))
+        return std::move(*v);
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <size_t I, typename... Types>
 constexpr auto& get(std::variant<Types...>& var) {
-    if (auto* v = std::get_if<I>(&var)) return *v;
+    if (auto* v = std::get_if<I>(&var))
+        return *v;
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <size_t I, typename... Types>
 constexpr const auto& get(const std::variant<Types...>& var) {
-    if (auto* v = std::get_if<I>(&var)) return *v;
+    if (auto* v = std::get_if<I>(&var))
+        return *v;
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <size_t I, typename... Types>
 constexpr const auto&& get(const std::variant<Types...>&& var) {
-    if (auto* v = std::get_if<I>(&var)) return std::move(*v);
+    if (auto* v = std::get_if<I>(&var))
+        return std::move(*v);
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 template <size_t I, typename... Types>
 constexpr auto&& get(std::variant<Types...>&& var) {
-    if (auto* v = std::get_if<I>(&var)) return std::move(*v);
+    if (auto* v = std::get_if<I>(&var))
+        return std::move(*v);
     throw std::runtime_error{"Bad variant access -- variant does not contain the requested type"};
 }
 
@@ -96,10 +104,12 @@ constexpr auto visit_helper(Visitor&& vis, Variant&& var, std::index_sequence<Is
 // don't need it).
 template <class Visitor, class Variant>
 constexpr auto visit(Visitor&& vis, Variant&& var) {
-    return visit_helper(std::forward<Visitor>(vis), std::forward<Variant>(var),
+    return visit_helper(
+            std::forward<Visitor>(vis),
+            std::forward<Variant>(var),
             std::make_index_sequence<std::variant_size_v<std::remove_reference_t<Variant>>>{});
 }
 
-} // namespace var
+}  // namespace var
 
 #endif

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <catch2/catch.hpp>
 #include <unordered_map>
-#include "oxenc/hex.h"
+
 #include "oxenc/base32z.h"
 #include "oxenc/base64.h"
 #include "oxenc/bt.h"
-
+#include "oxenc/hex.h"
 
 using namespace oxenc;

--- a/tests/test_bt.cpp
+++ b/tests/test_bt.cpp
@@ -1,19 +1,20 @@
-#include "common.h"
+#include <limits>
 #include <map>
 #include <set>
-#include <limits>
+
+#include "common.h"
 
 TEST_CASE("bt basic value serialization", "[bt][serialization]") {
     int x = 42;
     std::string x_ = bt_serialize(x);
-    REQUIRE( bt_serialize(x) == "i42e" );
+    REQUIRE(bt_serialize(x) == "i42e");
 
-    int64_t  ibig = -8'000'000'000'000'000'000LL;
+    int64_t ibig = -8'000'000'000'000'000'000LL;
     uint64_t ubig = 10'000'000'000'000'000'000ULL;
-    REQUIRE( bt_serialize(ibig) == "i-8000000000000000000e" );
-    REQUIRE( bt_serialize(std::numeric_limits<int64_t>::min()) == "i-9223372036854775808e" );
-    REQUIRE( bt_serialize(ubig) == "i10000000000000000000e" );
-    REQUIRE( bt_serialize(std::numeric_limits<uint64_t>::max()) == "i18446744073709551615e" );
+    REQUIRE(bt_serialize(ibig) == "i-8000000000000000000e");
+    REQUIRE(bt_serialize(std::numeric_limits<int64_t>::min()) == "i-9223372036854775808e");
+    REQUIRE(bt_serialize(ubig) == "i10000000000000000000e");
+    REQUIRE(bt_serialize(std::numeric_limits<uint64_t>::max()) == "i18446744073709551615e");
 
     std::unordered_map<std::string, int> m;
     m["hi"] = 123;
@@ -21,45 +22,45 @@ TEST_CASE("bt basic value serialization", "[bt][serialization]") {
     m["bye"] = 456;
     m["zap"] = 0;
     // bt values are always sorted:
-    REQUIRE( bt_serialize(m) == "d3:byei456e2:hii123e3:omgi-7890e3:zapi0ee" );
+    REQUIRE(bt_serialize(m) == "d3:byei456e2:hii123e3:omgi-7890e3:zapi0ee");
 
     // Dict-like list serializes as a dict (and get sorted, as above)
     std::list<std::pair<std::string, std::string>> d{{
-        {"c", "x"},
-        {"a", "z"},
-        {"b", "y"},
+            {"c", "x"},
+            {"a", "z"},
+            {"b", "y"},
     }};
-    REQUIRE( bt_serialize(d) == "d1:a1:z1:b1:y1:c1:xe" );
+    REQUIRE(bt_serialize(d) == "d1:a1:z1:b1:y1:c1:xe");
 
     std::vector<std::string> v{{"a", "", "\x00"s, "\x00\x00\x00goo"s}};
-    REQUIRE( bt_serialize(v) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv );
+    REQUIRE(bt_serialize(v) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv);
 
     std::array v2 = {"a"sv, ""sv, "\x00"sv, "\x00\x00\x00goo"sv};
-    REQUIRE( bt_serialize(v2) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv );
+    REQUIRE(bt_serialize(v2) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv);
 }
 
 TEST_CASE("bt nested value serialization", "[bt][serialization]") {
-    std::unordered_map<std::string, std::list<std::map<std::string, std::set<int>>>> x{{
-        {"foo", {{{"a", {1,2,3}}, {"b", {}}}, {{"c", {4,-5}}}}},
-        {"bar", {}}
-    }};
-    REQUIRE( bt_serialize(x) == "d3:barle3:foold1:ali1ei2ei3ee1:bleed1:cli-5ei4eeeee" );
+    std::unordered_map<std::string, std::list<std::map<std::string, std::set<int>>>> x{
+            {{"foo", {{{"a", {1, 2, 3}}, {"b", {}}}, {{"c", {4, -5}}}}}, {"bar", {}}}};
+    REQUIRE(bt_serialize(x) == "d3:barle3:foold1:ali1ei2ei3ee1:bleed1:cli-5ei4eeeee");
 }
 
 TEST_CASE("bt basic value deserialization", "[bt][deserialization]") {
-    REQUIRE( bt_deserialize<int>("i42e") == 42 );
+    REQUIRE(bt_deserialize<int>("i42e") == 42);
 
-    int64_t  ibig = -8'000'000'000'000'000'000LL;
+    int64_t ibig = -8'000'000'000'000'000'000LL;
     uint64_t ubig = 10'000'000'000'000'000'000ULL;
-    REQUIRE( bt_deserialize<int64_t>("i-8000000000000000000e") == ibig );
-    REQUIRE( bt_deserialize<uint64_t>("i10000000000000000000e") == ubig );
-    REQUIRE( bt_deserialize<int64_t>("i-9223372036854775808e") == std::numeric_limits<int64_t>::min() );
-    REQUIRE( bt_deserialize<uint64_t>("i18446744073709551615e") == std::numeric_limits<uint64_t>::max() );
-    REQUIRE( bt_deserialize<uint32_t>("i4294967295e") == std::numeric_limits<uint32_t>::max() );
+    REQUIRE(bt_deserialize<int64_t>("i-8000000000000000000e") == ibig);
+    REQUIRE(bt_deserialize<uint64_t>("i10000000000000000000e") == ubig);
+    REQUIRE(bt_deserialize<int64_t>("i-9223372036854775808e") ==
+            std::numeric_limits<int64_t>::min());
+    REQUIRE(bt_deserialize<uint64_t>("i18446744073709551615e") ==
+            std::numeric_limits<uint64_t>::max());
+    REQUIRE(bt_deserialize<uint32_t>("i4294967295e") == std::numeric_limits<uint32_t>::max());
 
-    REQUIRE_THROWS( bt_deserialize<int64_t>("i-9223372036854775809e") );
-    REQUIRE_THROWS( bt_deserialize<uint64_t>("i-1e") );
-    REQUIRE_THROWS( bt_deserialize<uint32_t>("i4294967296e") );
+    REQUIRE_THROWS(bt_deserialize<int64_t>("i-9223372036854775809e"));
+    REQUIRE_THROWS(bt_deserialize<uint64_t>("i-1e"));
+    REQUIRE_THROWS(bt_deserialize<uint32_t>("i4294967296e"));
 
     std::unordered_map<std::string, int> m;
     m["hi"] = 123;
@@ -67,261 +68,266 @@ TEST_CASE("bt basic value deserialization", "[bt][deserialization]") {
     m["bye"] = 456;
     m["zap"] = 0;
     // bt values are always sorted:
-    REQUIRE( bt_deserialize<std::unordered_map<std::string, int>>("d3:byei456e2:hii123e3:omgi-7890e3:zapi0ee") == m );
+    REQUIRE(bt_deserialize<std::unordered_map<std::string, int>>("d3:byei456e2:hii123e3:omgi-"
+                                                                 "7890e3:zapi0ee") == m);
 
     // Dict-like list can be used for deserialization
     std::list<std::pair<std::string, std::string>> d{{
-        {"a", "z"},
-        {"b", "y"},
-        {"c", "x"},
+            {"a", "z"},
+            {"b", "y"},
+            {"c", "x"},
     }};
-    REQUIRE( bt_deserialize<std::list<std::pair<std::string, std::string>>>("d1:a1:z1:b1:y1:c1:xe") == d );
+    REQUIRE(bt_deserialize<std::list<std::pair<std::string, std::string>>>("d1:a1:z1:b1:y1:c1:"
+                                                                           "xe") == d);
 
     std::vector<std::string> v{{"a", "", "\x00"s, "\x00\x00\x00goo"s}};
-    REQUIRE( bt_deserialize<std::vector<std::string>>("l1:a0:1:\0006:\x00\x00\x00gooe"sv) == v );
+    REQUIRE(bt_deserialize<std::vector<std::string>>("l1:a0:1:\0006:\x00\x00\x00gooe"sv) == v);
 
     std::vector v2 = {"a"sv, ""sv, "\x00"sv, "\x00\x00\x00goo"sv};
-    REQUIRE( bt_deserialize<decltype(v2)>("l1:a0:1:\0006:\x00\x00\x00gooe"sv) == v2 );
+    REQUIRE(bt_deserialize<decltype(v2)>("l1:a0:1:\0006:\x00\x00\x00gooe"sv) == v2);
 }
 
 TEST_CASE("bt_value serialization", "[bt][serialization][bt_value]") {
     bt_value dna{42};
     std::string x_ = bt_serialize(dna);
-    REQUIRE( bt_serialize(dna) == "i42e" );
+    REQUIRE(bt_serialize(dna) == "i42e");
 
     bt_value foo{"foo"};
-    REQUIRE( bt_serialize(foo) == "3:foo" );
+    REQUIRE(bt_serialize(foo) == "3:foo");
 
     bt_value ibig{-8'000'000'000'000'000'000LL};
     bt_value ubig{10'000'000'000'000'000'000ULL};
     int16_t ismall = -123;
     uint16_t usmall = 123;
     bt_dict nums{
-        {"a", 0},
-        {"b", -8'000'000'000'000'000'000LL},
-        {"c", 10'000'000'000'000'000'000ULL},
-        {"d", ismall},
-        {"e", usmall},
+            {"a", 0},
+            {"b", -8'000'000'000'000'000'000LL},
+            {"c", 10'000'000'000'000'000'000ULL},
+            {"d", ismall},
+            {"e", usmall},
     };
 
-    REQUIRE( bt_serialize(ibig) == "i-8000000000000000000e" );
-    REQUIRE( bt_serialize(ubig) == "i10000000000000000000e" );
-    REQUIRE( bt_serialize(nums) == "d1:ai0e1:bi-8000000000000000000e1:ci10000000000000000000e1:di-123e1:ei123ee" );
+    REQUIRE(bt_serialize(ibig) == "i-8000000000000000000e");
+    REQUIRE(bt_serialize(ubig) == "i10000000000000000000e");
+    REQUIRE(bt_serialize(nums) ==
+            "d1:ai0e1:bi-8000000000000000000e1:ci10000000000000000000e1:di-123e1:ei123ee");
 
     // Same as nested test, above, but with bt_* types
-    bt_dict x{{
-        {"foo", bt_list{{bt_dict{{ {"a", bt_list{{1,2,3}}}, {"b", bt_list{}}}}, bt_dict{{{"c", bt_list{{-5, 4}}}}}}}},
-        {"bar", bt_list{}}
-    }};
-    REQUIRE( bt_serialize(x) == "d3:barle3:foold1:ali1ei2ei3ee1:bleed1:cli-5ei4eeeee" );
+    bt_dict x{
+            {{"foo",
+              bt_list{
+                      {bt_dict{{{"a", bt_list{{1, 2, 3}}}, {"b", bt_list{}}}},
+                       bt_dict{{{"c", bt_list{{-5, 4}}}}}}}},
+             {"bar", bt_list{}}}};
+    REQUIRE(bt_serialize(x) == "d3:barle3:foold1:ali1ei2ei3ee1:bleed1:cli-5ei4eeeee");
     std::vector<std::string> v{{"a", "", "\x00"s, "\x00\x00\x00goo"s}};
-    REQUIRE( bt_serialize(v) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv );
+    REQUIRE(bt_serialize(v) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv);
 
     std::array v2 = {"a"sv, ""sv, "\x00"sv, "\x00\x00\x00goo"sv};
-    REQUIRE( bt_serialize(v2) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv );
+    REQUIRE(bt_serialize(v2) == "l1:a0:1:\0006:\x00\x00\x00gooe"sv);
 }
 
 TEST_CASE("bt_value deserialization", "[bt][deserialization][bt_value]") {
     auto dna1 = bt_deserialize<bt_value>("i42e");
     auto dna2 = bt_deserialize<bt_value>("i-42e");
-    REQUIRE( var::get<uint64_t>(dna1) == 42 );
-    REQUIRE( var::get<int64_t>(dna2) == -42 );
-    REQUIRE_THROWS( var::get<int64_t>(dna1) );
-    REQUIRE_THROWS( var::get<uint64_t>(dna2) );
-    REQUIRE( oxenc::get_int<int>(dna1) == 42 );
-    REQUIRE( oxenc::get_int<int>(dna2) == -42 );
-    REQUIRE( oxenc::get_int<unsigned>(dna1) == 42 );
-    REQUIRE_THROWS( oxenc::get_int<unsigned>(dna2) );
+    REQUIRE(var::get<uint64_t>(dna1) == 42);
+    REQUIRE(var::get<int64_t>(dna2) == -42);
+    REQUIRE_THROWS(var::get<int64_t>(dna1));
+    REQUIRE_THROWS(var::get<uint64_t>(dna2));
+    REQUIRE(oxenc::get_int<int>(dna1) == 42);
+    REQUIRE(oxenc::get_int<int>(dna2) == -42);
+    REQUIRE(oxenc::get_int<unsigned>(dna1) == 42);
+    REQUIRE_THROWS(oxenc::get_int<unsigned>(dna2));
 
     bt_value x = bt_deserialize<bt_value>("d3:barle3:foold1:ali1ei2ei3ee1:bleed1:cli-5ei4eeeee");
-    REQUIRE( std::holds_alternative<bt_dict>(x) );
+    REQUIRE(std::holds_alternative<bt_dict>(x));
     bt_dict& a = var::get<bt_dict>(x);
-    REQUIRE( a.count("bar") );
-    REQUIRE( a.count("foo") );
-    REQUIRE( a.size() == 2 );
+    REQUIRE(a.count("bar"));
+    REQUIRE(a.count("foo"));
+    REQUIRE(a.size() == 2);
     bt_list& foo = var::get<bt_list>(a["foo"]);
-    REQUIRE( foo.size() == 2 );
+    REQUIRE(foo.size() == 2);
     bt_dict& foo1 = var::get<bt_dict>(foo.front());
     bt_dict& foo2 = var::get<bt_dict>(foo.back());
-    REQUIRE( foo1.size() == 2 );
-    REQUIRE( foo2.size() == 1 );
+    REQUIRE(foo1.size() == 2);
+    REQUIRE(foo2.size() == 1);
     bt_list& foo1a = var::get<bt_list>(foo1.at("a"));
     bt_list& foo1b = var::get<bt_list>(foo1.at("b"));
     bt_list& foo2c = var::get<bt_list>(foo2.at("c"));
     std::list<int> foo1a_vals, foo1b_vals, foo2c_vals;
-    for (auto& v : foo1a) foo1a_vals.push_back(oxenc::get_int<int>(v));
-    for (auto& v : foo1b) foo1b_vals.push_back(oxenc::get_int<int>(v));
-    for (auto& v : foo2c) foo2c_vals.push_back(oxenc::get_int<int>(v));
-    REQUIRE( foo1a_vals == std::list{{1,2,3}} );
-    REQUIRE( foo1b_vals == std::list<int>{} );
-    REQUIRE( foo2c_vals == std::list{{-5, 4}} );
+    for (auto& v : foo1a)
+        foo1a_vals.push_back(oxenc::get_int<int>(v));
+    for (auto& v : foo1b)
+        foo1b_vals.push_back(oxenc::get_int<int>(v));
+    for (auto& v : foo2c)
+        foo2c_vals.push_back(oxenc::get_int<int>(v));
+    REQUIRE(foo1a_vals == std::list{{1, 2, 3}});
+    REQUIRE(foo1b_vals == std::list<int>{});
+    REQUIRE(foo2c_vals == std::list{{-5, 4}});
 
-    REQUIRE( var::get<bt_list>(a.at("bar")).empty() );
+    REQUIRE(var::get<bt_list>(a.at("bar")).empty());
 }
 
 TEST_CASE("bt tuple serialization", "[bt][tuple][serialization]") {
     // Deserializing directly into a tuple:
-    std::tuple<int, std::string, std::vector<int>> x{42, "hi", {{1,2,3,4,5}}};
-    REQUIRE( bt_serialize(x) == "li42e2:hili1ei2ei3ei4ei5eee" );
+    std::tuple<int, std::string, std::vector<int>> x{42, "hi", {{1, 2, 3, 4, 5}}};
+    REQUIRE(bt_serialize(x) == "li42e2:hili1ei2ei3ei4ei5eee");
 
     using Y = std::tuple<std::string, std::string, std::unordered_map<std::string, int>>;
-    REQUIRE( bt_deserialize<Y>("l5:hello3:omgd1:ai1e1:bi2eee")
-            == Y{"hello", "omg", {{"a",1}, {"b",2}}} );
+    REQUIRE(bt_deserialize<Y>("l5:hello3:omgd1:ai1e1:bi2eee") ==
+            Y{"hello", "omg", {{"a", 1}, {"b", 2}}});
 
     using Z = std::tuple<std::tuple<int, std::string, std::string>, std::pair<int, int>>;
     Z z{{3, "abc", "def"}, {4, 5}};
-    REQUIRE( bt_serialize(z) == "lli3e3:abc3:defeli4ei5eee" );
-    REQUIRE( bt_deserialize<Z>("lli6e3:ghi3:jkleli7ei8eee") == Z{{6, "ghi", "jkl"}, {7, 8}} );
+    REQUIRE(bt_serialize(z) == "lli3e3:abc3:defeli4ei5eee");
+    REQUIRE(bt_deserialize<Z>("lli6e3:ghi3:jkleli7ei8eee") == Z{{6, "ghi", "jkl"}, {7, 8}});
 
     using W = std::pair<std::string, std::pair<int, unsigned>>;
-    REQUIRE( bt_serialize(W{"zzzzzzzzzz", {42, 42}}) == "l10:zzzzzzzzzzli42ei42eee" );
+    REQUIRE(bt_serialize(W{"zzzzzzzzzz", {42, 42}}) == "l10:zzzzzzzzzzli42ei42eee");
 
-    REQUIRE_THROWS( bt_deserialize<std::tuple<int>>("li1e") ); // missing closing e
-    REQUIRE_THROWS( bt_deserialize<std::pair<int, int>>("li1ei-4e") ); // missing closing e
-    REQUIRE_THROWS( bt_deserialize<std::tuple<int>>("li1ei2ee") ); // too many elements
-    REQUIRE_THROWS( bt_deserialize<std::pair<int, int>>("li1ei-2e0:e") ); // too many elements
-    REQUIRE_THROWS( bt_deserialize<std::tuple<int, int>>("li1ee") ); // too few elements
-    REQUIRE_THROWS( bt_deserialize<std::pair<int, int>>("li1ee") ); // too few elements
-    REQUIRE_THROWS( bt_deserialize<std::tuple<std::string>>("li1ee") ); // wrong element type
-    REQUIRE_THROWS( bt_deserialize<std::pair<int, std::string>>("li1ei8ee") ); // wrong element type
-    REQUIRE_THROWS( bt_deserialize<std::pair<int, std::string>>("l1:x1:xe") ); // wrong element type
+    REQUIRE_THROWS(bt_deserialize<std::tuple<int>>("li1e"));                  // missing closing e
+    REQUIRE_THROWS(bt_deserialize<std::pair<int, int>>("li1ei-4e"));          // missing closing e
+    REQUIRE_THROWS(bt_deserialize<std::tuple<int>>("li1ei2ee"));              // too many elements
+    REQUIRE_THROWS(bt_deserialize<std::pair<int, int>>("li1ei-2e0:e"));       // too many elements
+    REQUIRE_THROWS(bt_deserialize<std::tuple<int, int>>("li1ee"));            // too few elements
+    REQUIRE_THROWS(bt_deserialize<std::pair<int, int>>("li1ee"));             // too few elements
+    REQUIRE_THROWS(bt_deserialize<std::tuple<std::string>>("li1ee"));         // wrong element type
+    REQUIRE_THROWS(bt_deserialize<std::pair<int, std::string>>("li1ei8ee"));  // wrong element type
+    REQUIRE_THROWS(bt_deserialize<std::pair<int, std::string>>("l1:x1:xe"));  // wrong element type
 
     // Converting from a generic bt_value/bt_list:
     bt_value a = bt_get("l5:hello3:omgi12345ee");
     using V1 = std::tuple<std::string, std::string_view, uint16_t>;
-    REQUIRE( get_tuple<V1>(a) == V1{"hello", "omg"sv, 12345} );
+    REQUIRE(get_tuple<V1>(a) == V1{"hello", "omg"sv, 12345});
 
     bt_value b = bt_get("l5:hellod1:ai1e1:bi2eee");
     using V2 = std::pair<std::string_view, bt_dict>;
-    REQUIRE( get_tuple<V2>(b) == V2{"hello", {{"a",1U}, {"b",2U}}} );
+    REQUIRE(get_tuple<V2>(b) == V2{"hello", {{"a", 1U}, {"b", 2U}}});
 
     bt_value c = bt_get("l5:helloi-4ed1:ai-1e1:bi-2eee");
     using V3 = std::tuple<std::string, int, bt_dict>;
-    REQUIRE( get_tuple<V3>(c) == V3{"hello", -4, {{"a",-1}, {"b",-2}}} );
+    REQUIRE(get_tuple<V3>(c) == V3{"hello", -4, {{"a", -1}, {"b", -2}}});
 
-    REQUIRE_THROWS( get_tuple<V1>(bt_get("l5:hello3:omge")) ); // too few
-    REQUIRE_THROWS( get_tuple<V1>(bt_get("l5:hello3:omgi1ei1ee")) ); // too many
-    REQUIRE_THROWS( get_tuple<V1>(bt_get("l5:helloi1ei1ee")) ); // wrong type
+    REQUIRE_THROWS(get_tuple<V1>(bt_get("l5:hello3:omge")));        // too few
+    REQUIRE_THROWS(get_tuple<V1>(bt_get("l5:hello3:omgi1ei1ee")));  // too many
+    REQUIRE_THROWS(get_tuple<V1>(bt_get("l5:helloi1ei1ee")));       // wrong type
 
     // Construct a bt_value from tuples:
     bt_value l{std::make_tuple(3, 4, "hi"sv)};
-    REQUIRE( bt_serialize(l) == "li3ei4e2:hie" );
+    REQUIRE(bt_serialize(l) == "li3ei4e2:hie");
     bt_list m{{1, 2, std::make_tuple(3, 4, "hi"sv), std::make_pair("foo"s, "bar"sv), -4}};
-    REQUIRE( bt_serialize(m) == "li1ei2eli3ei4e2:hiel3:foo3:barei-4ee" );
-
+    REQUIRE(bt_serialize(m) == "li1ei2eli3ei4e2:hiel3:foo3:barei-4ee");
 }
 
 TEST_CASE("bt allocation-free consumer", "[bt][dict][list][consumer]") {
 
     // Consumer deserialization:
     bt_list_consumer lc{"li1ei2eli3ei4e2:hiel3:foo3:barei-4ee"};
-    REQUIRE( lc.consume_integer<int>() == 1 );
-    REQUIRE( lc.consume_integer<int>() == 2 );
-    REQUIRE( lc.consume_list<std::tuple<int, int, std::string>>() == std::make_tuple(3, 4, "hi"s) );
-    REQUIRE( lc.consume_list<std::pair<std::string_view, std::string_view>>() == std::make_pair("foo"sv, "bar"sv) );
-    REQUIRE( lc.consume_integer<int>() == -4 );
+    REQUIRE(lc.consume_integer<int>() == 1);
+    REQUIRE(lc.consume_integer<int>() == 2);
+    REQUIRE(lc.consume_list<std::tuple<int, int, std::string>>() == std::make_tuple(3, 4, "hi"s));
+    REQUIRE(lc.consume_list<std::pair<std::string_view, std::string_view>>() ==
+            std::make_pair("foo"sv, "bar"sv));
+    REQUIRE(lc.consume_integer<int>() == -4);
 
     bt_dict_consumer dc{"d1:Ai0e1:ali1e3:omge1:bli1ei2ei3eee"};
-    REQUIRE( dc.key() == "A" );
-    REQUIRE( dc.skip_until("a") );
-    REQUIRE( dc.next_list<std::pair<int8_t, std::string_view>>() ==
-            std::make_pair("a"sv, std::make_pair(int8_t{1}, "omg"sv)) );
-    REQUIRE( dc.next_list<std::tuple<int, int, int>>() ==
-            std::make_pair("b"sv, std::make_tuple(1, 2, 3)) );
+    REQUIRE(dc.key() == "A");
+    REQUIRE(dc.skip_until("a"));
+    REQUIRE(dc.next_list<std::pair<int8_t, std::string_view>>() ==
+            std::make_pair("a"sv, std::make_pair(int8_t{1}, "omg"sv)));
+    REQUIRE(dc.next_list<std::tuple<int, int, int>>() ==
+            std::make_pair("b"sv, std::make_tuple(1, 2, 3)));
 }
 
 TEST_CASE("bt allocation-free list producer", "[bt][list][producer]") {
 
     char smallbuf[16];
-    bt_list_producer toosmall{smallbuf, 16}; // le, total = 2
-    toosmall += 42; // i42e, total = 6
-    toosmall += "abcdefgh"; // 8:abcdefgh, total=16
-    CHECK( toosmall.view() == "li42e8:abcdefghe" );
+    bt_list_producer toosmall{smallbuf, 16};  // le, total = 2
+    toosmall += 42;                           // i42e, total = 6
+    toosmall += "abcdefgh";                   // 8:abcdefgh, total=16
+    CHECK(toosmall.view() == "li42e8:abcdefghe");
 
-    CHECK_THROWS_AS( toosmall += "", std::length_error );
+    CHECK_THROWS_AS(toosmall += "", std::length_error);
 
     char buf[1024];
     bt_list_producer lp{buf, sizeof(buf)};
-    CHECK( lp.view() == "le" );
-    CHECK( (void*) lp.end() == (void*) (buf + 2) );
+    CHECK(lp.view() == "le");
+    CHECK((void*)lp.end() == (void*)(buf + 2));
 
     lp.append("abc");
-    CHECK( lp.view() == "l3:abce" );
+    CHECK(lp.view() == "l3:abce");
     lp += 42;
-    CHECK( lp.view() == "l3:abci42ee" );
+    CHECK(lp.view() == "l3:abci42ee");
     std::vector<int> randos = {{1, 17, -999}};
     lp.append(randos.begin(), randos.end());
-    CHECK( lp.view() == "l3:abci42ei1ei17ei-999ee" );
+    CHECK(lp.view() == "l3:abci42ei1ei17ei-999ee");
 
     {
         auto sublist = lp.append_list();
-        CHECK_THROWS_AS( lp.append(1), std::logic_error );
-        CHECK( sublist.view() == "le" );
-        CHECK( lp.view() == "l3:abci42ei1ei17ei-999elee" );
+        CHECK_THROWS_AS(lp.append(1), std::logic_error);
+        CHECK(sublist.view() == "le");
+        CHECK(lp.view() == "l3:abci42ei1ei17ei-999elee");
         sublist.append(0);
 
         auto sublist2{std::move(sublist)};
         sublist2 += "";
-        CHECK( sublist2.view() == "li0e0:e" );
-        CHECK( lp.view() == "l3:abci42ei1ei17ei-999eli0e0:ee" );
+        CHECK(sublist2.view() == "li0e0:e");
+        CHECK(lp.view() == "l3:abci42ei1ei17ei-999eli0e0:ee");
     }
 
     lp.append_list().append_list().append_list() += "omg"s;
-    CHECK( lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeee" );
+    CHECK(lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeee");
 
     {
         auto dict = lp.append_dict();
-        CHECK( dict.view() == "de" );
-        CHECK( lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeedee" );
+        CHECK(dict.view() == "de");
+        CHECK(lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeedee");
 
-        CHECK_THROWS_AS( lp.append(1), std::logic_error );
+        CHECK_THROWS_AS(lp.append(1), std::logic_error);
 
         dict.append("foo", "bar");
         dict.append("g", 42);
 
-        CHECK( dict.view() == "d3:foo3:bar1:gi42ee" );
-        CHECK( lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeed3:foo3:bar1:gi42eee" );
+        CHECK(dict.view() == "d3:foo3:bar1:gi42ee");
+        CHECK(lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeed3:foo3:bar1:gi42eee");
 
         dict.append_list("h").append_dict().append_dict("a").append_list("A") += 999;
-        CHECK( dict.view() == "d3:foo3:bar1:gi42e1:hld1:ad1:Ali999eeeeee" );
-        CHECK( lp.view() == "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeed3:foo3:bar1:gi42e1:hld1:ad1:Ali999eeeeeee" );
+        CHECK(dict.view() == "d3:foo3:bar1:gi42e1:hld1:ad1:Ali999eeeeee");
+        CHECK(lp.view() ==
+              "l3:abci42ei1ei17ei-999eli0e0:elll3:omgeeed3:foo3:bar1:gi42e1:hld1:ad1:"
+              "Ali999eeeeeee");
     }
-
 }
 
 TEST_CASE("bt allocation-free dict producer", "[bt][dict][producer]") {
 
     char buf[1024];
     bt_dict_producer dp{buf, sizeof(buf)};
-    CHECK( dp.view() == "de" );
-    CHECK( (void*) dp.end() == (void*) (buf + 2) );
+    CHECK(dp.view() == "de");
+    CHECK((void*)dp.end() == (void*)(buf + 2));
 
     dp.append("foo", "bar");
-    CHECK( dp.view() == "d3:foo3:bare" );
+    CHECK(dp.view() == "d3:foo3:bare");
     dp.append("foo\0"sv, -333222111);
-    CHECK( dp.view() == "d3:foo3:bar4:foo\0i-333222111ee"sv );
+    CHECK(dp.view() == "d3:foo3:bar4:foo\0i-333222111ee"sv);
     {
         auto sublist = dp.append_list("myList");
         ((sublist += "") += 2) += 42;
-        CHECK( sublist.view() == "l0:i2ei42ee" );
+        CHECK(sublist.view() == "l0:i2ei42ee");
     }
-    CHECK( dp.view() == "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42eee"sv );
+    CHECK(dp.view() == "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42eee"sv);
     {
         auto subd = dp.append_dict("p");
         subd.append("", "");
-        CHECK( subd.view() == "d0:0:e" );
+        CHECK(subd.view() == "d0:0:e");
     }
-    CHECK( dp.view() == "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:0:ee"sv );
+    CHECK(dp.view() == "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:0:ee"sv);
 
-    std::map<std::string, int> to_append{
-        {"q", 1},
-        {"r", 2},
-        {"~", 3},
-        {"~1", 4}};
+    std::map<std::string, int> to_append{{"q", 1}, {"r", 2}, {"~", 3}, {"~1", 4}};
     dp.append(to_append.begin(), to_append.end());
 
-    CHECK( dp.view() ==
-        "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:0:e1:qi1e1:ri2e1:~i3e2:~1i4ee"sv );
+    CHECK(dp.view() ==
+          "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:0:e1:qi1e1:ri2e1:~i3e2:~1i4ee"sv);
 }
 
 TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {
@@ -329,13 +335,7 @@ TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {
     char buf[1024];
     bt_dict_producer x{buf, sizeof(buf)};
 
-    bt_dict more{
-        {"b", 1},
-        {"c", bt_dict{
-            {"d", "e"},
-            {"f", bt_list{{1,2,3}}}
-        }}
-    };
+    bt_dict more{{"b", 1}, {"c", bt_dict{{"d", "e"}, {"f", bt_list{{1, 2, 3}}}}}};
     bt_dict tiny{{"a", ""}};
 
     x.append("a", 42);
@@ -343,7 +343,7 @@ TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {
     x.append_bt("y", bt_list{{tiny}});
     x.append_bt("z", more);
 
-    CHECK( x.view() == "d1:ai42e1:xd1:a0:e1:yld1:a0:ee1:zd1:bi1e1:cd1:d1:e1:fli1ei2ei3eeeee" );
+    CHECK(x.view() == "d1:ai42e1:xd1:a0:e1:yld1:a0:ee1:zd1:bi1e1:cd1:d1:e1:fli1ei2ei3eeeee");
 
     bt_list_producer y{buf, sizeof(buf)};
     y.append(123);
@@ -352,36 +352,43 @@ TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {
     y.append_bt(bt_list{{tiny}});
     y.append("~");
 
-    CHECK( y.view() == "li123ed1:bi1e1:cd1:d1:e1:fli1ei2ei3eeeed1:a0:eld1:a0:ee1:~e" );
+    CHECK(y.view() == "li123ed1:bi1e1:cd1:d1:e1:fli1ei2ei3eeeed1:a0:eld1:a0:ee1:~e");
 }
 
 #ifdef OXENC_APPLE_TO_CHARS_WORKAROUND
 TEST_CASE("apple to_chars workaround test", "[bt][apple][sucks]") {
     char buf[20];
-    auto buf_view = [&](char* end) { return std::string_view{buf, static_cast<size_t>(end - buf)}; };
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 0)) == "0" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 1)) == "1" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 2)) == "2" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 10)) == "10" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 42)) == "42" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 99)) == "99" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, 1234567890)) == "1234567890" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, -1)) == "-1" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, -2)) == "-2" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, -10)) == "-10" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, -99)) == "-99" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, -1234567890)) == "-1234567890" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, char{42})) == "42" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, (unsigned char){42})) == "42" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, short{42})) == "42" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<char>::min())) == "-128" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<char>::max())) == "127" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, (unsigned char){42})) == "42" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<uint64_t>::max())) == "18446744073709551615" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, int64_t{-1})) == "-1" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<int64_t>::min())) == "-9223372036854775808" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, int64_t{-9223372036854775807})) == "-9223372036854775807" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, int64_t{9223372036854775807})) == "9223372036854775807" );
-    CHECK( buf_view(oxenc::apple_to_chars10(buf, int64_t{9223372036854775806})) == "9223372036854775806" );
+    auto buf_view = [&](char* end) {
+        return std::string_view{buf, static_cast<size_t>(end - buf)};
+    };
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 0)) == "0");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 1)) == "1");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 2)) == "2");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 10)) == "10");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 42)) == "42");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 99)) == "99");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, 1234567890)) == "1234567890");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, -1)) == "-1");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, -2)) == "-2");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, -10)) == "-10");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, -99)) == "-99");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, -1234567890)) == "-1234567890");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, char{42})) == "42");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, (unsigned char){42})) == "42");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, short{42})) == "42");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<char>::min())) == "-128");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<char>::max())) == "127");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, (unsigned char){42})) == "42");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<uint64_t>::max())) ==
+          "18446744073709551615");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, int64_t{-1})) == "-1");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, std::numeric_limits<int64_t>::min())) ==
+          "-9223372036854775808");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, int64_t{-9223372036854775807})) ==
+          "-9223372036854775807");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, int64_t{9223372036854775807})) ==
+          "9223372036854775807");
+    CHECK(buf_view(oxenc::apple_to_chars10(buf, int64_t{9223372036854775806})) ==
+          "9223372036854775806");
 }
 #endif

--- a/tests/test_encoding.cpp
+++ b/tests/test_encoding.cpp
@@ -1,317 +1,343 @@
-#include "common.h"
 #include <iterator>
+
+#include "common.h"
 
 using namespace std::literals;
 using namespace oxenc::literals;
 
-const std::string pk = "\xf1\x6b\xa5\x59\x10\x39\xf0\x89\xb4\x2a\x83\x41\x75\x09\x30\x94\x07\x4d\x0d\x93\x7a\x79\xe5\x3e\x5c\xe7\x30\xf9\x46\xe1\x4b\x88";
+const std::string pk =
+        "\xf1\x6b\xa5\x59\x10\x39\xf0\x89\xb4\x2a\x83\x41\x75\x09\x30\x94\x07\x4d\x0d\x93\x7a\x79"
+        "\xe5\x3e\x5c\xe7\x30\xf9\x46\xe1\x4b\x88";
 const std::string pk_hex = "f16ba5591039f089b42a834175093094074d0d937a79e53e5ce730f946e14b88";
 const std::string pk_b32z = "6fi4kseo88aeupbkopyzknjo1odw4dcuxjh6kx1hhhax1tzbjqry";
 const std::string pk_b64 = "8WulWRA58Im0KoNBdQkwlAdNDZN6eeU+XOcw+UbhS4g=";
 
 TEST_CASE("hex encoding/decoding", "[encoding][decoding][hex]") {
-    REQUIRE( oxenc::to_hex("\xff\x42\x12\x34") == "ff421234"s );
+    REQUIRE(oxenc::to_hex("\xff\x42\x12\x34") == "ff421234"s);
     std::vector<uint8_t> chars{{1, 10, 100, 254}};
     std::array<uint8_t, 8> out;
     std::array<uint8_t, 8> expected{{'0', '1', '0', 'a', '6', '4', 'f', 'e'}};
     oxenc::to_hex(chars.begin(), chars.end(), out.begin());
-    REQUIRE( out == expected );
+    REQUIRE(out == expected);
 
-    REQUIRE( oxenc::to_hex(chars.begin(), chars.end()) == "010a64fe" );
+    REQUIRE(oxenc::to_hex(chars.begin(), chars.end()) == "010a64fe");
 
-    REQUIRE( oxenc::from_hex("12345678ffEDbca9") == "\x12\x34\x56\x78\xff\xed\xbc\xa9"s );
-    REQUIRE( "12345678ffEDbca9"_hex == "\x12\x34\x56\x78\xff\xed\xbc\xa9"s );
-    REQUIRE_THROWS_AS( "abc"_hex, std::invalid_argument );
-    REQUIRE_THROWS_AS( "abcg"_hex, std::invalid_argument );
+    REQUIRE(oxenc::from_hex("12345678ffEDbca9") == "\x12\x34\x56\x78\xff\xed\xbc\xa9"s);
+    REQUIRE("12345678ffEDbca9"_hex == "\x12\x34\x56\x78\xff\xed\xbc\xa9"s);
+    REQUIRE_THROWS_AS("abc"_hex, std::invalid_argument);
+    REQUIRE_THROWS_AS("abcg"_hex, std::invalid_argument);
 
-    REQUIRE( oxenc::is_hex("1234567890abcdefABCDEF1234567890abcdefABCDEF") );
-    REQUIRE_FALSE( oxenc::is_hex("1234567890abcdefABCDEF1234567890aGcdefABCDEF") );
+    REQUIRE(oxenc::is_hex("1234567890abcdefABCDEF1234567890abcdefABCDEF"));
+    REQUIRE_FALSE(oxenc::is_hex("1234567890abcdefABCDEF1234567890aGcdefABCDEF"));
     //                                                              ^
-    REQUIRE_FALSE( oxenc::is_hex("1234567890abcdefABCDEF1234567890agcdefABCDEF") );
+    REQUIRE_FALSE(oxenc::is_hex("1234567890abcdefABCDEF1234567890agcdefABCDEF"));
     //                                                              ^
-    REQUIRE_FALSE( oxenc::is_hex("\x11\xff") );
+    REQUIRE_FALSE(oxenc::is_hex("\x11\xff"));
     constexpr auto odd_hex = "1234567890abcdefABCDEF1234567890abcdefABCDE"sv;
-    REQUIRE_FALSE( oxenc::is_hex(odd_hex) );
-    REQUIRE_FALSE( oxenc::is_hex("0") );
+    REQUIRE_FALSE(oxenc::is_hex(odd_hex));
+    REQUIRE_FALSE(oxenc::is_hex("0"));
 
-    REQUIRE( std::all_of(odd_hex.begin(), odd_hex.end(), oxenc::is_hex_digit<char>) );
+    REQUIRE(std::all_of(odd_hex.begin(), odd_hex.end(), oxenc::is_hex_digit<char>));
 
-    REQUIRE( oxenc::from_hex(pk_hex) == pk );
-    REQUIRE( oxenc::to_hex(pk) == pk_hex );
+    REQUIRE(oxenc::from_hex(pk_hex) == pk);
+    REQUIRE(oxenc::to_hex(pk) == pk_hex);
 
-    REQUIRE( oxenc::from_hex(pk_hex.begin(), pk_hex.end()) == pk );
+    REQUIRE(oxenc::from_hex(pk_hex.begin(), pk_hex.end()) == pk);
 
-    std::vector<std::byte> bytes{{std::byte{0xff}, std::byte{0x42}, std::byte{0x12}, std::byte{0x34}}};
+    std::vector<std::byte> bytes{
+            {std::byte{0xff}, std::byte{0x42}, std::byte{0x12}, std::byte{0x34}}};
     std::basic_string_view<std::byte> b{bytes.data(), bytes.size()};
-    REQUIRE( oxenc::to_hex(b) == "ff421234"s );
+    REQUIRE(oxenc::to_hex(b) == "ff421234"s);
 
     // In-place decoding and truncation via to_hex's returned iterator:
     std::string some_hex = "48656c6c6f";
-    some_hex.erase(oxenc::from_hex(some_hex.begin(), some_hex.end(), some_hex.begin()), some_hex.end());
-    REQUIRE( some_hex == "Hello" );
+    some_hex.erase(
+            oxenc::from_hex(some_hex.begin(), some_hex.end(), some_hex.begin()), some_hex.end());
+    REQUIRE(some_hex == "Hello");
 
     // Test the returned iterator from encoding
     std::string hellohex;
     *oxenc::to_hex(some_hex.begin(), some_hex.end(), std::back_inserter(hellohex))++ = '!';
-    REQUIRE( hellohex == "48656c6c6f!" );
+    REQUIRE(hellohex == "48656c6c6f!");
 
     bytes.resize(8);
-    bytes[0] = std::byte{'f'}; bytes[1] = std::byte{'f'}; bytes[2] = std::byte{'4'}; bytes[3] = std::byte{'2'};
-    bytes[4] = std::byte{'1'}; bytes[5] = std::byte{'2'}; bytes[6] = std::byte{'3'}; bytes[7] = std::byte{'4'};
+    bytes[0] = std::byte{'f'};
+    bytes[1] = std::byte{'f'};
+    bytes[2] = std::byte{'4'};
+    bytes[3] = std::byte{'2'};
+    bytes[4] = std::byte{'1'};
+    bytes[5] = std::byte{'2'};
+    bytes[6] = std::byte{'3'};
+    bytes[7] = std::byte{'4'};
     std::basic_string_view<std::byte> hex_bytes{bytes.data(), bytes.size()};
-    REQUIRE( oxenc::is_hex(hex_bytes) );
-    REQUIRE( oxenc::from_hex(hex_bytes) == "\xff\x42\x12\x34" );
+    REQUIRE(oxenc::is_hex(hex_bytes));
+    REQUIRE(oxenc::from_hex(hex_bytes) == "\xff\x42\x12\x34");
 
-    REQUIRE( oxenc::to_hex_size(1) == 2 );
-    REQUIRE( oxenc::to_hex_size(2) == 4 );
-    REQUIRE( oxenc::to_hex_size(3) == 6 );
-    REQUIRE( oxenc::to_hex_size(4) == 8 );
-    REQUIRE( oxenc::to_hex_size(100) == 200 );
-    REQUIRE( oxenc::from_hex_size(2) == 1 );
-    REQUIRE( oxenc::from_hex_size(4) == 2 );
-    REQUIRE( oxenc::from_hex_size(6) == 3 );
-    REQUIRE( oxenc::from_hex_size(98) == 49 );
+    REQUIRE(oxenc::to_hex_size(1) == 2);
+    REQUIRE(oxenc::to_hex_size(2) == 4);
+    REQUIRE(oxenc::to_hex_size(3) == 6);
+    REQUIRE(oxenc::to_hex_size(4) == 8);
+    REQUIRE(oxenc::to_hex_size(100) == 200);
+    REQUIRE(oxenc::from_hex_size(2) == 1);
+    REQUIRE(oxenc::from_hex_size(4) == 2);
+    REQUIRE(oxenc::from_hex_size(6) == 3);
+    REQUIRE(oxenc::from_hex_size(98) == 49);
 }
 
 TEST_CASE("base32z encoding/decoding", "[encoding][decoding][base32z]") {
-    REQUIRE( oxenc::to_base32z("\0\0\0\0\0"s) == "yyyyyyyy" );
-    REQUIRE( oxenc::to_base32z("\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv)
-            == "yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo");
+    REQUIRE(oxenc::to_base32z("\0\0\0\0\0"s) == "yyyyyyyy");
+    REQUIRE(oxenc::to_base32z(
+                    "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv) ==
+            "yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo");
 
-    REQUIRE( oxenc::from_base32z("yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo")
-            == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+    REQUIRE(oxenc::from_base32z("yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo") ==
+            "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
 
-    REQUIRE( oxenc::from_base32z("YRTWK3HJIXG66YJDEIUAUK6P7HY1GTM8TGIH55ABRPNSXNPM3ZZO")
-            == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+    REQUIRE(oxenc::from_base32z("YRTWK3HJIXG66YJDEIUAUK6P7HY1GTM8TGIH55ABRPNSXNPM3ZZO") ==
+            "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
 
-    REQUIRE( "yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo"_b32z
-            == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
-    REQUIRE( "YRTWK3HJIXG66YJDEIUAUK6P7HY1GTM8TGIH55ABRPNSXNPM3ZZO"_b32z
-            == "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
-    REQUIRE_THROWS_AS( "abcl"_b32z, std::invalid_argument );
+    REQUIRE("yrtwk3hjixg66yjdeiuauk6p7hy1gtm8tgih55abrpnsxnpm3zzo"_b32z ==
+            "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+    REQUIRE("YRTWK3HJIXG66YJDEIUAUK6P7HY1GTM8TGIH55ABRPNSXNPM3ZZO"_b32z ==
+            "\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"sv);
+    REQUIRE_THROWS_AS("abcl"_b32z, std::invalid_argument);
 
     auto five_nulls = oxenc::from_base32z("yyyyyyyy");
-    REQUIRE( five_nulls.size() == 5 );
-    REQUIRE( five_nulls == "\0\0\0\0\0"s );
+    REQUIRE(five_nulls.size() == 5);
+    REQUIRE(five_nulls == "\0\0\0\0\0"s);
 
     // 00000 00001 00010 00011 00100 00101 00110 00111
     // ==
     // 00000000 01000100 00110010 00010100 11000111
-    REQUIRE( oxenc::from_base32z("ybndrfg8") == "\x00\x44\x32\x14\xc7"s );
+    REQUIRE(oxenc::from_base32z("ybndrfg8") == "\x00\x44\x32\x14\xc7"s);
 
-    // Special case 1: 7 base32z digits with 3 trailing 0 bits -> 4 bytes (the trailing 0s are dropped)
-    // 00000 00001 00010 00011 00100 00101 11000
+    // Special case 1: 7 base32z digits with 3 trailing 0 bits -> 4 bytes (the trailing 0s are
+    // dropped) 00000 00001 00010 00011 00100 00101 11000
     // ==
     // 00000000 01000100 00110010 00010111
-    REQUIRE( oxenc::from_base32z("ybndrfa") == "\x00\x44\x32\x17"s );
+    REQUIRE(oxenc::from_base32z("ybndrfa") == "\x00\x44\x32\x17"s);
 
     // Round-trip it:
-    REQUIRE( oxenc::from_base32z(oxenc::to_base32z("\x00\x44\x32\x17"sv)) == "\x00\x44\x32\x17"sv );
-    REQUIRE( oxenc::to_base32z(oxenc::from_base32z("ybndrfa")) == "ybndrfa" );
+    REQUIRE(oxenc::from_base32z(oxenc::to_base32z("\x00\x44\x32\x17"sv)) == "\x00\x44\x32\x17"sv);
+    REQUIRE(oxenc::to_base32z(oxenc::from_base32z("ybndrfa")) == "ybndrfa");
 
     // Special case 2: 7 base32z digits with 3 trailing bits 010; we just ignore the trailing stuff,
     // as if it was specified as 0.  (The last digit here is 11010 instead of 11000).
-    REQUIRE( oxenc::from_base32z("ybndrf4") == "\x00\x44\x32\x17"s );
+    REQUIRE(oxenc::from_base32z("ybndrf4") == "\x00\x44\x32\x17"s);
     // This one won't round-trip to the same value since it has ignored garbage bytes at the end
-    REQUIRE( oxenc::to_base32z(oxenc::from_base32z("ybndrf4"s)) == "ybndrfa" );
+    REQUIRE(oxenc::to_base32z(oxenc::from_base32z("ybndrf4"s)) == "ybndrfa");
 
-    REQUIRE( oxenc::to_base32z(pk) == pk_b32z );
-    REQUIRE( oxenc::to_base32z(pk.begin(), pk.end()) == pk_b32z );
-    REQUIRE( oxenc::from_base32z(pk_b32z) == pk );
-    REQUIRE( oxenc::from_base32z(pk_b32z.begin(), pk_b32z.end()) == pk );
+    REQUIRE(oxenc::to_base32z(pk) == pk_b32z);
+    REQUIRE(oxenc::to_base32z(pk.begin(), pk.end()) == pk_b32z);
+    REQUIRE(oxenc::from_base32z(pk_b32z) == pk);
+    REQUIRE(oxenc::from_base32z(pk_b32z.begin(), pk_b32z.end()) == pk);
 
     std::string pk_b32z_again, pk_again;
     oxenc::to_base32z(pk.begin(), pk.end(), std::back_inserter(pk_b32z_again));
     oxenc::from_base32z(pk_b32z.begin(), pk_b32z.end(), std::back_inserter(pk_again));
-    REQUIRE( pk_b32z_again == pk_b32z );
-    REQUIRE( pk_again == pk );
+    REQUIRE(pk_b32z_again == pk_b32z);
+    REQUIRE(pk_again == pk);
 
     // In-place decoding and truncation via returned iterator:
     std::string some_b32z = "jb1sa5dx";
-    some_b32z.erase(oxenc::from_base32z(some_b32z.begin(), some_b32z.end(), some_b32z.begin()), some_b32z.end());
-    REQUIRE( some_b32z == "Hello" );
+    some_b32z.erase(
+            oxenc::from_base32z(some_b32z.begin(), some_b32z.end(), some_b32z.begin()),
+            some_b32z.end());
+    REQUIRE(some_b32z == "Hello");
 
     // Test the returned iterator from encoding
     std::string hellob32z;
     *oxenc::to_base32z(some_b32z.begin(), some_b32z.end(), std::back_inserter(hellob32z))++ = '!';
-    REQUIRE( hellob32z == "jb1sa5dx!" );
+    REQUIRE(hellob32z == "jb1sa5dx!");
 
     std::vector<std::byte> bytes{{std::byte{0}, std::byte{255}}};
     std::basic_string_view<std::byte> b{bytes.data(), bytes.size()};
-    REQUIRE( oxenc::to_base32z(b) == "yd9o" );
+    REQUIRE(oxenc::to_base32z(b) == "yd9o");
 
     bytes.resize(4);
-    bytes[0] = std::byte{'y'}; bytes[1] = std::byte{'d'}; bytes[2] = std::byte{'9'}; bytes[3] = std::byte{'o'};
+    bytes[0] = std::byte{'y'};
+    bytes[1] = std::byte{'d'};
+    bytes[2] = std::byte{'9'};
+    bytes[3] = std::byte{'o'};
     std::basic_string_view<std::byte> b32_bytes{bytes.data(), bytes.size()};
-    REQUIRE( oxenc::is_base32z(b32_bytes) );
-    REQUIRE( oxenc::from_base32z(b32_bytes) == "\x00\xff"sv );
+    REQUIRE(oxenc::is_base32z(b32_bytes));
+    REQUIRE(oxenc::from_base32z(b32_bytes) == "\x00\xff"sv);
 
-    REQUIRE( oxenc::is_base32z("") );
-    REQUIRE_FALSE( oxenc::is_base32z("y") );
-    REQUIRE( oxenc::is_base32z("yy") );
-    REQUIRE_FALSE( oxenc::is_base32z("yyy") );
-    REQUIRE( oxenc::is_base32z("yyyy") );
-    REQUIRE( oxenc::is_base32z("yyyyy") );
-    REQUIRE_FALSE( oxenc::is_base32z("yyyyyy") );
-    REQUIRE( oxenc::is_base32z("yyyyyyy") );
-    REQUIRE( oxenc::is_base32z("yyyyyyyy") );
+    REQUIRE(oxenc::is_base32z(""));
+    REQUIRE_FALSE(oxenc::is_base32z("y"));
+    REQUIRE(oxenc::is_base32z("yy"));
+    REQUIRE_FALSE(oxenc::is_base32z("yyy"));
+    REQUIRE(oxenc::is_base32z("yyyy"));
+    REQUIRE(oxenc::is_base32z("yyyyy"));
+    REQUIRE_FALSE(oxenc::is_base32z("yyyyyy"));
+    REQUIRE(oxenc::is_base32z("yyyyyyy"));
+    REQUIRE(oxenc::is_base32z("yyyyyyyy"));
 
-    REQUIRE( oxenc::to_base32z_size(1) == 2 );
-    REQUIRE( oxenc::to_base32z_size(2) == 4 );
-    REQUIRE( oxenc::to_base32z_size(3) == 5 );
-    REQUIRE( oxenc::to_base32z_size(4) == 7 );
-    REQUIRE( oxenc::to_base32z_size(5) == 8 );
-    REQUIRE( oxenc::to_base32z_size(30) == 48 );
-    REQUIRE( oxenc::to_base32z_size(31) == 50 );
-    REQUIRE( oxenc::to_base32z_size(32) == 52 );
-    REQUIRE( oxenc::to_base32z_size(33) == 53 );
-    REQUIRE( oxenc::to_base32z_size(100) == 160 );
-    REQUIRE( oxenc::from_base32z_size(160) == 100 );
-    REQUIRE( oxenc::from_base32z_size(53) == 33 );
-    REQUIRE( oxenc::from_base32z_size(52) == 32 );
-    REQUIRE( oxenc::from_base32z_size(50) == 31 );
-    REQUIRE( oxenc::from_base32z_size(48) == 30 );
-    REQUIRE( oxenc::from_base32z_size(8) == 5 );
-    REQUIRE( oxenc::from_base32z_size(7) == 4 );
-    REQUIRE( oxenc::from_base32z_size(5) == 3 );
-    REQUIRE( oxenc::from_base32z_size(4) == 2 );
-    REQUIRE( oxenc::from_base32z_size(2) == 1 );
+    REQUIRE(oxenc::to_base32z_size(1) == 2);
+    REQUIRE(oxenc::to_base32z_size(2) == 4);
+    REQUIRE(oxenc::to_base32z_size(3) == 5);
+    REQUIRE(oxenc::to_base32z_size(4) == 7);
+    REQUIRE(oxenc::to_base32z_size(5) == 8);
+    REQUIRE(oxenc::to_base32z_size(30) == 48);
+    REQUIRE(oxenc::to_base32z_size(31) == 50);
+    REQUIRE(oxenc::to_base32z_size(32) == 52);
+    REQUIRE(oxenc::to_base32z_size(33) == 53);
+    REQUIRE(oxenc::to_base32z_size(100) == 160);
+    REQUIRE(oxenc::from_base32z_size(160) == 100);
+    REQUIRE(oxenc::from_base32z_size(53) == 33);
+    REQUIRE(oxenc::from_base32z_size(52) == 32);
+    REQUIRE(oxenc::from_base32z_size(50) == 31);
+    REQUIRE(oxenc::from_base32z_size(48) == 30);
+    REQUIRE(oxenc::from_base32z_size(8) == 5);
+    REQUIRE(oxenc::from_base32z_size(7) == 4);
+    REQUIRE(oxenc::from_base32z_size(5) == 3);
+    REQUIRE(oxenc::from_base32z_size(4) == 2);
+    REQUIRE(oxenc::from_base32z_size(2) == 1);
 }
 
 TEST_CASE("base64 encoding/decoding", "[encoding][decoding][base64]") {
     // 00000000 00000000 00000000 -> 000000 000000 000000 000000
-    REQUIRE( oxenc::to_base64("\0\0\0"s) == "AAAA" );
+    REQUIRE(oxenc::to_base64("\0\0\0"s) == "AAAA");
     // 00000001 00000002 00000003 -> 000000 010000 000200 000003
-    REQUIRE( oxenc::to_base64("\x01\x02\x03"s) == "AQID" );
-    REQUIRE( oxenc::to_base64("\0\0\0\0"s) == "AAAAAA==" );
+    REQUIRE(oxenc::to_base64("\x01\x02\x03"s) == "AQID");
+    REQUIRE(oxenc::to_base64("\0\0\0\0"s) == "AAAAAA==");
     // 00000000 00000000 00000000  11111111 ->
     // 000000 000000 000000 000000 111111 110000 (pad) (pad)
-    REQUIRE( oxenc::to_base64("a")   == "YQ==" );
-    REQUIRE( oxenc::to_base64("ab")  == "YWI=" );
-    REQUIRE( oxenc::to_base64("abc") == "YWJj" );
-    REQUIRE( oxenc::to_base64("abcd")   == "YWJjZA==" );
-    REQUIRE( oxenc::to_base64("abcde")  == "YWJjZGU=" );
-    REQUIRE( oxenc::to_base64("abcdef") == "YWJjZGVm" );
+    REQUIRE(oxenc::to_base64("a") == "YQ==");
+    REQUIRE(oxenc::to_base64("ab") == "YWI=");
+    REQUIRE(oxenc::to_base64("abc") == "YWJj");
+    REQUIRE(oxenc::to_base64("abcd") == "YWJjZA==");
+    REQUIRE(oxenc::to_base64("abcde") == "YWJjZGU=");
+    REQUIRE(oxenc::to_base64("abcdef") == "YWJjZGVm");
 
-    REQUIRE( oxenc::to_base64_unpadded("a")   == "YQ" );
-    REQUIRE( oxenc::to_base64_unpadded("ab")  == "YWI" );
-    REQUIRE( oxenc::to_base64_unpadded("abc") == "YWJj" );
-    REQUIRE( oxenc::to_base64_unpadded("abcd")   == "YWJjZA" );
-    REQUIRE( oxenc::to_base64_unpadded("abcde")  == "YWJjZGU" );
-    REQUIRE( oxenc::to_base64_unpadded("abcdef") == "YWJjZGVm" );
+    REQUIRE(oxenc::to_base64_unpadded("a") == "YQ");
+    REQUIRE(oxenc::to_base64_unpadded("ab") == "YWI");
+    REQUIRE(oxenc::to_base64_unpadded("abc") == "YWJj");
+    REQUIRE(oxenc::to_base64_unpadded("abcd") == "YWJjZA");
+    REQUIRE(oxenc::to_base64_unpadded("abcde") == "YWJjZGU");
+    REQUIRE(oxenc::to_base64_unpadded("abcdef") == "YWJjZGVm");
 
-    REQUIRE( oxenc::to_base64("\0\0\0\xff"s) == "AAAA/w==" );
-    REQUIRE( oxenc::to_base64("\0\0\0\xff\xff"s) == "AAAA//8=" );
-    REQUIRE( oxenc::to_base64("\0\0\0\xff\xff\xff"s) == "AAAA////" );
-    REQUIRE( oxenc::to_base64(
-            "Man is distinguished, not only by his reason, but by this singular passion from other "
-            "animals, which is a lust of the mind, that by a perseverance of delight in the "
-            "continued and indefatigable generation of knowledge, exceeds the short vehemence of "
-            "any carnal pleasure.")
-            ==
+    REQUIRE(oxenc::to_base64("\0\0\0\xff"s) == "AAAA/w==");
+    REQUIRE(oxenc::to_base64("\0\0\0\xff\xff"s) == "AAAA//8=");
+    REQUIRE(oxenc::to_base64("\0\0\0\xff\xff\xff"s) == "AAAA////");
+    REQUIRE(oxenc::to_base64("Man is distinguished, not only by his reason, but by this singular "
+                             "passion from other "
+                             "animals, which is a lust of the mind, that by a perseverance of "
+                             "delight in the "
+                             "continued and indefatigable generation of knowledge, exceeds the "
+                             "short vehemence of "
+                             "any carnal pleasure.") ==
             "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz"
             "IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg"
             "dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu"
             "dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo"
-            "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=" );
+            "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=");
 
-    REQUIRE( oxenc::from_base64("A+/A") == "\x03\xef\xc0" );
-    REQUIRE( oxenc::from_base64("YWJj") == "abc" );
-    REQUIRE( oxenc::from_base64("YWJjZA==") == "abcd" );
-    REQUIRE( oxenc::from_base64("YWJjZA") == "abcd" );
-    REQUIRE( oxenc::from_base64("YWJjZB") == "abcd" ); // ignore superfluous bits
-    REQUIRE( oxenc::from_base64("YWJjZB") == "abcd" ); // ignore superfluous bits
-    REQUIRE( oxenc::from_base64("YWJj+") == "abc" ); // ignore superfluous bits
-    REQUIRE( oxenc::from_base64("YWJjZGU=") == "abcde" );
-    REQUIRE( oxenc::from_base64("YWJjZGU") == "abcde" );
-    REQUIRE( oxenc::from_base64("YWJjZGVm") == "abcdef" );
+    REQUIRE(oxenc::from_base64("A+/A") == "\x03\xef\xc0");
+    REQUIRE(oxenc::from_base64("YWJj") == "abc");
+    REQUIRE(oxenc::from_base64("YWJjZA==") == "abcd");
+    REQUIRE(oxenc::from_base64("YWJjZA") == "abcd");
+    REQUIRE(oxenc::from_base64("YWJjZB") == "abcd");  // ignore superfluous bits
+    REQUIRE(oxenc::from_base64("YWJjZB") == "abcd");  // ignore superfluous bits
+    REQUIRE(oxenc::from_base64("YWJj+") == "abc");    // ignore superfluous bits
+    REQUIRE(oxenc::from_base64("YWJjZGU=") == "abcde");
+    REQUIRE(oxenc::from_base64("YWJjZGU") == "abcde");
+    REQUIRE(oxenc::from_base64("YWJjZGVm") == "abcdef");
 
-    REQUIRE( oxenc::is_base64("YWJjZGVm") );
-    REQUIRE( oxenc::is_base64("YWJjZGU") );
-    REQUIRE( oxenc::is_base64("YWJjZGU=") );
-    REQUIRE( oxenc::is_base64("YWJjZA==") );
-    REQUIRE( oxenc::is_base64("YWJjZA") );
-    REQUIRE( oxenc::is_base64("YWJjZB") ); // not really valid, but we explicitly accept it
+    REQUIRE(oxenc::is_base64("YWJjZGVm"));
+    REQUIRE(oxenc::is_base64("YWJjZGU"));
+    REQUIRE(oxenc::is_base64("YWJjZGU="));
+    REQUIRE(oxenc::is_base64("YWJjZA=="));
+    REQUIRE(oxenc::is_base64("YWJjZA"));
+    REQUIRE(oxenc::is_base64("YWJjZB"));  // not really valid, but we explicitly accept it
 
-    REQUIRE_FALSE( oxenc::is_base64("YWJjZ=") ); // invalid padding (padding can only be 4th or 3rd+4th of a 4-char block)
-    REQUIRE_FALSE( oxenc::is_base64("YYYYA") ); // invalid: base64 can never be length 4n+1
-    REQUIRE_FALSE( oxenc::is_base64("YWJj=") );
-    REQUIRE_FALSE( oxenc::is_base64("YWJj=A") );
-    REQUIRE_FALSE( oxenc::is_base64("YWJjA===") );
-    REQUIRE_FALSE( oxenc::is_base64("YWJ[") );
-    REQUIRE_FALSE( oxenc::is_base64("YWJ.") );
-    REQUIRE_FALSE( oxenc::is_base64("_YWJ") );
+    REQUIRE_FALSE(oxenc::is_base64(
+            "YWJjZ="));  // invalid padding (padding can only be 4th or 3rd+4th of a 4-char block)
+    REQUIRE_FALSE(oxenc::is_base64("YYYYA"));  // invalid: base64 can never be length 4n+1
+    REQUIRE_FALSE(oxenc::is_base64("YWJj="));
+    REQUIRE_FALSE(oxenc::is_base64("YWJj=A"));
+    REQUIRE_FALSE(oxenc::is_base64("YWJjA==="));
+    REQUIRE_FALSE(oxenc::is_base64("YWJ["));
+    REQUIRE_FALSE(oxenc::is_base64("YWJ."));
+    REQUIRE_FALSE(oxenc::is_base64("_YWJ"));
 
-    REQUIRE( oxenc::from_base64(
-            "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz"
-            "IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg"
-            "dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu"
-            "dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo"
-            "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=" )
-            ==
+    REQUIRE(oxenc::from_base64("TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCB"
+                               "ieSB0aGlz"
+                               "IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx"
+                               "1c3Qgb2Yg"
+                               "dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGU"
+                               "gY29udGlu"
+                               "dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGN"
+                               "lZWRzIHRo"
+                               "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=") ==
             "Man is distinguished, not only by his reason, but by this singular passion from other "
             "animals, which is a lust of the mind, that by a perseverance of delight in the "
             "continued and indefatigable generation of knowledge, exceeds the short vehemence of "
             "any carnal pleasure.");
 
-    REQUIRE( "SGVsbG8="_b64 == "Hello" );
-    REQUIRE( "SGVsbG8"_b64 == "Hello" );
-    REQUIRE_THROWS_AS( "SGVsbG8$"_b64, std::invalid_argument );
+    REQUIRE("SGVsbG8="_b64 == "Hello");
+    REQUIRE("SGVsbG8"_b64 == "Hello");
+    REQUIRE_THROWS_AS("SGVsbG8$"_b64, std::invalid_argument);
 
-    REQUIRE( oxenc::to_base64(pk) == pk_b64 );
-    REQUIRE( oxenc::to_base64(pk.begin(), pk.end()) == pk_b64 );
-    REQUIRE( oxenc::from_base64(pk_b64) == pk );
-    REQUIRE( oxenc::from_base64(pk_b64.begin(), pk_b64.end()) == pk );
+    REQUIRE(oxenc::to_base64(pk) == pk_b64);
+    REQUIRE(oxenc::to_base64(pk.begin(), pk.end()) == pk_b64);
+    REQUIRE(oxenc::from_base64(pk_b64) == pk);
+    REQUIRE(oxenc::from_base64(pk_b64.begin(), pk_b64.end()) == pk);
 
     std::string pk_b64_again, pk_again;
     oxenc::to_base64(pk.begin(), pk.end(), std::back_inserter(pk_b64_again));
     oxenc::from_base64(pk_b64.begin(), pk_b64.end(), std::back_inserter(pk_again));
-    REQUIRE( pk_b64_again == pk_b64 );
-    REQUIRE( pk_again == pk );
+    REQUIRE(pk_b64_again == pk_b64);
+    REQUIRE(pk_again == pk);
 
     // In-place decoding and truncation via returned iterator:
     std::string some_b64 = "SGVsbG8=";
-    some_b64.erase(oxenc::from_base64(some_b64.begin(), some_b64.end(), some_b64.begin()), some_b64.end());
-    REQUIRE( some_b64 == "Hello" );
+    some_b64.erase(
+            oxenc::from_base64(some_b64.begin(), some_b64.end(), some_b64.begin()), some_b64.end());
+    REQUIRE(some_b64 == "Hello");
 
     // Test the returned iterator from encoding
     std::string hellob64;
     *oxenc::to_base64(some_b64.begin(), some_b64.end(), std::back_inserter(hellob64))++ = '!';
-    REQUIRE( hellob64 == "SGVsbG8=!" );
+    REQUIRE(hellob64 == "SGVsbG8=!");
 
     std::vector<std::byte> bytes{{std::byte{0}, std::byte{255}}};
     std::basic_string_view<std::byte> b{bytes.data(), bytes.size()};
-    REQUIRE( oxenc::to_base64(b) == "AP8=" );
+    REQUIRE(oxenc::to_base64(b) == "AP8=");
 
     bytes.resize(4);
-    bytes[0] = std::byte{'/'}; bytes[1] = std::byte{'w'}; bytes[2] = std::byte{'A'}; bytes[3] = std::byte{'='};
+    bytes[0] = std::byte{'/'};
+    bytes[1] = std::byte{'w'};
+    bytes[2] = std::byte{'A'};
+    bytes[3] = std::byte{'='};
     std::basic_string_view<std::byte> b64_bytes{bytes.data(), bytes.size()};
-    REQUIRE( oxenc::is_base64(b64_bytes) );
-    REQUIRE( oxenc::from_base64(b64_bytes) == "\xff\x00"sv );
+    REQUIRE(oxenc::is_base64(b64_bytes));
+    REQUIRE(oxenc::from_base64(b64_bytes) == "\xff\x00"sv);
 
-    REQUIRE( oxenc::to_base64_size(1) == 4 );
-    REQUIRE( oxenc::to_base64_size(2) == 4 );
-    REQUIRE( oxenc::to_base64_size(3) == 4 );
-    REQUIRE( oxenc::to_base64_size(4) == 8 );
-    REQUIRE( oxenc::to_base64_size(5) == 8 );
-    REQUIRE( oxenc::to_base64_size(6) == 8 );
-    REQUIRE( oxenc::to_base64_size(30) == 40 );
-    REQUIRE( oxenc::to_base64_size(31) == 44 );
-    REQUIRE( oxenc::to_base64_size(32) == 44 );
-    REQUIRE( oxenc::to_base64_size(33) == 44 );
-    REQUIRE( oxenc::to_base64_size(100) == 136 );
-    REQUIRE( oxenc::from_base64_size(136) == 102 ); // Not symmetric because we don't know the last two are padding
-    REQUIRE( oxenc::from_base64_size(134) == 100 ); // Unpadded
-    REQUIRE( oxenc::from_base64_size(44) == 33 );
-    REQUIRE( oxenc::from_base64_size(43) == 32 );
-    REQUIRE( oxenc::from_base64_size(42) == 31 );
-    REQUIRE( oxenc::from_base64_size(40) == 30 );
-    REQUIRE( oxenc::from_base64_size(8) == 6 );
-    REQUIRE( oxenc::from_base64_size(7) == 5 );
-    REQUIRE( oxenc::from_base64_size(6) == 4 );
-    REQUIRE( oxenc::from_base64_size(4) == 3 );
-    REQUIRE( oxenc::from_base64_size(3) == 2 );
-    REQUIRE( oxenc::from_base64_size(2) == 1 );
+    REQUIRE(oxenc::to_base64_size(1) == 4);
+    REQUIRE(oxenc::to_base64_size(2) == 4);
+    REQUIRE(oxenc::to_base64_size(3) == 4);
+    REQUIRE(oxenc::to_base64_size(4) == 8);
+    REQUIRE(oxenc::to_base64_size(5) == 8);
+    REQUIRE(oxenc::to_base64_size(6) == 8);
+    REQUIRE(oxenc::to_base64_size(30) == 40);
+    REQUIRE(oxenc::to_base64_size(31) == 44);
+    REQUIRE(oxenc::to_base64_size(32) == 44);
+    REQUIRE(oxenc::to_base64_size(33) == 44);
+    REQUIRE(oxenc::to_base64_size(100) == 136);
+    REQUIRE(oxenc::from_base64_size(136) ==
+            102);  // Not symmetric because we don't know the last two are padding
+    REQUIRE(oxenc::from_base64_size(134) == 100);  // Unpadded
+    REQUIRE(oxenc::from_base64_size(44) == 33);
+    REQUIRE(oxenc::from_base64_size(43) == 32);
+    REQUIRE(oxenc::from_base64_size(42) == 31);
+    REQUIRE(oxenc::from_base64_size(40) == 30);
+    REQUIRE(oxenc::from_base64_size(8) == 6);
+    REQUIRE(oxenc::from_base64_size(7) == 5);
+    REQUIRE(oxenc::from_base64_size(6) == 4);
+    REQUIRE(oxenc::from_base64_size(4) == 3);
+    REQUIRE(oxenc::from_base64_size(3) == 2);
+    REQUIRE(oxenc::from_base64_size(2) == 1);
 }
 
 TEST_CASE("transcoding", "[decoding][encoding][base32z][hex][base64]") {
@@ -336,50 +362,50 @@ TEST_CASE("transcoding", "[decoding][encoding][base32z][hex][base64]") {
     std::string x;
     auto xx = std::back_inserter(x);
     std::copy(in64, in64.end(), xx);
-    REQUIRE( x == pk );
+    REQUIRE(x == pk);
     x.clear();
     std::copy(in32z, in32z.end(), xx);
-    REQUIRE( x == pk );
+    REQUIRE(x == pk);
     x.clear();
     std::copy(in16, in16.end(), xx);
-    REQUIRE( x == pk );
+    REQUIRE(x == pk);
 
     // Transcoding
     x.clear();
     std::copy(b64_to_hex, b64_to_hex.end(), xx);
-    CHECK( x == pk_hex );
+    CHECK(x == pk_hex);
 
     x.clear();
     std::copy(b64_to_b32z, b64_to_b32z.end(), xx);
-    CHECK( x == pk_b32z );
+    CHECK(x == pk_b32z);
 
     x.clear();
     std::copy(b64_to_b64, b64_to_b64.end(), xx);
-    CHECK( x == pk_b64 );
+    CHECK(x == pk_b64);
 
     x.clear();
     std::copy(b32z_to_hex, b32z_to_hex.end(), xx);
-    CHECK( x == pk_hex );
+    CHECK(x == pk_hex);
 
     x.clear();
     std::copy(b32z_to_b32z, b32z_to_b32z.end(), xx);
-    CHECK( x == pk_b32z );
+    CHECK(x == pk_b32z);
 
     x.clear();
     std::copy(b32z_to_b64, b32z_to_b64.end(), xx);
-    CHECK( x == pk_b64 );
+    CHECK(x == pk_b64);
 
     x.clear();
     std::copy(hex_to_hex, hex_to_hex.end(), xx);
-    CHECK( x == pk_hex );
+    CHECK(x == pk_hex);
 
     x.clear();
     std::copy(hex_to_b32z, hex_to_b32z.end(), xx);
-    CHECK( x == pk_b32z );
+    CHECK(x == pk_b32z);
 
     x.clear();
     std::copy(hex_to_b64, hex_to_b64.end(), xx);
-    CHECK( x == pk_b64 );
+    CHECK(x == pk_b64);
 
     // Make a big chain of conversions
     oxenc::base32z_encoder it1{in64, in64.end()};
@@ -389,13 +415,13 @@ TEST_CASE("transcoding", "[decoding][encoding][base32z][hex][base64]") {
     oxenc::hex_encoder it5{it4, it4.end()};
     x.clear();
     std::copy(it5, it5.end(), xx);
-    CHECK( x == pk_hex );
+    CHECK(x == pk_hex);
 
     // No-padding b64 encoding:
     oxenc::base64_encoder b64_nopad{pk.begin(), pk.end(), false};
     x.clear();
     std::copy(b64_nopad, b64_nopad.end(), xx);
-    CHECK( x == pk_b64.substr(0, pk_b64.size()-1) );
+    CHECK(x == pk_b64.substr(0, pk_b64.size() - 1));
 }
 
 TEST_CASE("std::byte decoding", "[decoding][hex][base32z][base64]") {
@@ -407,32 +433,36 @@ TEST_CASE("std::byte decoding", "[decoding][hex][base32z][base64]") {
     auto b_in = "ff42"s;
     std::vector<std::byte> b_out;
     oxenc::from_hex(b_in.begin(), b_in.end(), std::back_inserter(b_out));
-    REQUIRE( b_out == std::vector{std::byte{0xff}, std::byte{0x42}} );
+    REQUIRE(b_out == std::vector{std::byte{0xff}, std::byte{0x42}});
     b_out.emplace_back();
     oxenc::from_hex(b_in.begin(), b_in.end(), b_out.begin() + 1);
-    REQUIRE( b_out == std::vector{std::byte{0xff}, std::byte{0xff}, std::byte{0x42}} );
+    REQUIRE(b_out == std::vector{std::byte{0xff}, std::byte{0xff}, std::byte{0x42}});
     oxenc::from_hex(b_in.begin(), b_in.end(), b_out.data());
-    REQUIRE( b_out == std::vector{std::byte{0xff}, std::byte{0x42}, std::byte{0x42}} );
+    REQUIRE(b_out == std::vector{std::byte{0xff}, std::byte{0x42}, std::byte{0x42}});
 
     // base32z
     b_in = "yojky"s;
     b_out.clear();
     oxenc::from_base32z(b_in.begin(), b_in.end(), std::back_inserter(b_out));
-    REQUIRE( b_out == std::vector{std::byte{0x04}, std::byte{0x12}, std::byte{0xa0}} );
+    REQUIRE(b_out == std::vector{std::byte{0x04}, std::byte{0x12}, std::byte{0xa0}});
     b_out.emplace_back();
     oxenc::from_base32z(b_in.begin(), b_in.end(), b_out.begin() + 1);
-    REQUIRE( b_out == std::vector{std::byte{0x04}, std::byte{0x04}, std::byte{0x12}, std::byte{0xa0}} );
+    REQUIRE(b_out ==
+            std::vector{std::byte{0x04}, std::byte{0x04}, std::byte{0x12}, std::byte{0xa0}});
     oxenc::from_base32z(b_in.begin(), b_in.end(), b_out.data());
-    REQUIRE( b_out == std::vector{std::byte{0x04}, std::byte{0x12}, std::byte{0xa0}, std::byte{0xa0}} );
+    REQUIRE(b_out ==
+            std::vector{std::byte{0x04}, std::byte{0x12}, std::byte{0xa0}, std::byte{0xa0}});
 
     // base64
     b_in = "yojk"s;
     b_out.clear();
     oxenc::from_base64(b_in.begin(), b_in.end(), std::back_inserter(b_out));
-    REQUIRE( b_out == std::vector{std::byte{0xca}, std::byte{0x88}, std::byte{0xe4}} );
+    REQUIRE(b_out == std::vector{std::byte{0xca}, std::byte{0x88}, std::byte{0xe4}});
     b_out.emplace_back();
     oxenc::from_base64(b_in.begin(), b_in.end(), b_out.begin() + 1);
-    REQUIRE( b_out == std::vector{std::byte{0xca}, std::byte{0xca}, std::byte{0x88}, std::byte{0xe4}} );
+    REQUIRE(b_out ==
+            std::vector{std::byte{0xca}, std::byte{0xca}, std::byte{0x88}, std::byte{0xe4}});
     oxenc::from_base64(b_in.begin(), b_in.end(), b_out.data());
-    REQUIRE( b_out == std::vector{std::byte{0xca}, std::byte{0x88}, std::byte{0xe4}, std::byte{0xe4}} );
+    REQUIRE(b_out ==
+            std::vector{std::byte{0xca}, std::byte{0x88}, std::byte{0xe4}, std::byte{0xe4}});
 }

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -10,13 +10,13 @@ TEST_CASE("endian swapping", "[endian]") {
     uint64_t u64 = 0x0123456789abcdef;
 
     byteswap_inplace(u8);
-    CHECK( u8 == 0x12 );
+    CHECK(u8 == 0x12);
     byteswap_inplace(u16);
-    CHECK( u16 == 0x3412 );
+    CHECK(u16 == 0x3412);
     byteswap_inplace(u32);
-    CHECK( u32 == 0x78563412 );
+    CHECK(u32 == 0x78563412);
     byteswap_inplace(u64);
-    CHECK( u64 == 0xefcdab8967452301 );
+    CHECK(u64 == 0xefcdab8967452301);
 }
 
 TEST_CASE("native to little", "[endian][little]") {
@@ -30,61 +30,61 @@ TEST_CASE("native to little", "[endian][little]") {
     constexpr uint32_t u32_little = little_endian ? 0x01234567 : 0x67452301;
     constexpr uint64_t u64_little = little_endian ? 0x0123456789abcdef : 0xefcdab8967452301;
 
-    CHECK( host_to_little(u8) == u8_little );
-    CHECK( host_to_little(u16) == u16_little );
-    CHECK( host_to_little(u32) == u32_little );
-    CHECK( host_to_little(u64) == u64_little );
+    CHECK(host_to_little(u8) == u8_little);
+    CHECK(host_to_little(u16) == u16_little);
+    CHECK(host_to_little(u32) == u32_little);
+    CHECK(host_to_little(u64) == u64_little);
 
     // The above should not have mutated:
-    REQUIRE( u8 == 0x01 );
-    REQUIRE( u16 == 0x0123 );
-    REQUIRE( u32 == 0x01234567 );
-    REQUIRE( u64 == 0x0123456789abcdef );
+    REQUIRE(u8 == 0x01);
+    REQUIRE(u16 == 0x0123);
+    REQUIRE(u32 == 0x01234567);
+    REQUIRE(u64 == 0x0123456789abcdef);
 
     host_to_little_inplace(u8);
     host_to_little_inplace(u16);
     host_to_little_inplace(u32);
     host_to_little_inplace(u64);
-    CHECK( u8 == u8_little );
-    CHECK( u16 == u16_little );
-    CHECK( u32 == u32_little );
-    CHECK( u64 == u64_little );
+    CHECK(u8 == u8_little);
+    CHECK(u16 == u16_little);
+    CHECK(u32 == u32_little);
+    CHECK(u64 == u64_little);
 
-    CHECK( little_to_host(u8) == 0x01 );
-    CHECK( little_to_host(u16) == 0x0123 );
-    CHECK( little_to_host(u32) == 0x01234567 );
-    CHECK( little_to_host(u64) == 0x0123456789abcdef );
+    CHECK(little_to_host(u8) == 0x01);
+    CHECK(little_to_host(u16) == 0x0123);
+    CHECK(little_to_host(u32) == 0x01234567);
+    CHECK(little_to_host(u64) == 0x0123456789abcdef);
 
     little_to_host_inplace(u8);
     little_to_host_inplace(u16);
     little_to_host_inplace(u32);
     little_to_host_inplace(u64);
-    CHECK( u8 == 0x01 );
-    CHECK( u16 == 0x0123 );
-    CHECK( u32 == 0x01234567 );
-    CHECK( u64 == 0x0123456789abcdef );
+    CHECK(u8 == 0x01);
+    CHECK(u16 == 0x0123);
+    CHECK(u32 == 0x01234567);
+    CHECK(u64 == 0x0123456789abcdef);
 
     const char* data = "\xef\xcd\xab\x89\x67\x45\x23\x01";
-    CHECK( load_little_to_host<uint8_t>(data) == 0xef );
-    CHECK( load_little_to_host<uint16_t>(data) == 0xcdef );
-    CHECK( load_little_to_host<uint32_t>(data) == 0x89abcdef );
-    CHECK( load_little_to_host<uint64_t>(data) == 0x0123456789abcdef );
+    CHECK(load_little_to_host<uint8_t>(data) == 0xef);
+    CHECK(load_little_to_host<uint16_t>(data) == 0xcdef);
+    CHECK(load_little_to_host<uint32_t>(data) == 0x89abcdef);
+    CHECK(load_little_to_host<uint64_t>(data) == 0x0123456789abcdef);
 
-    CHECK( load_host_to_little<uint8_t>(data) == 0xef );
-    CHECK( load_host_to_little<uint16_t>(data) == 0xcdef );
-    CHECK( load_host_to_little<uint32_t>(data) == 0x89abcdef );
-    CHECK( load_host_to_little<uint64_t>(data) == 0x0123456789abcdef );
+    CHECK(load_host_to_little<uint8_t>(data) == 0xef);
+    CHECK(load_host_to_little<uint16_t>(data) == 0xcdef);
+    CHECK(load_host_to_little<uint32_t>(data) == 0x89abcdef);
+    CHECK(load_host_to_little<uint64_t>(data) == 0x0123456789abcdef);
 
     char buf[8] = {0};
     std::string_view buffer{buf, 8};
     write_host_as_little(u8, buf);
-    CHECK( buffer.substr(0, 1) == "\x01" );
+    CHECK(buffer.substr(0, 1) == "\x01");
     write_host_as_little(u16, buf);
-    CHECK( buffer.substr(0, 2) == "\x23\x01" );
+    CHECK(buffer.substr(0, 2) == "\x23\x01");
     write_host_as_little(u32, buf);
-    CHECK( buffer.substr(0, 4) == "\x67\x45\x23\x01" );
+    CHECK(buffer.substr(0, 4) == "\x67\x45\x23\x01");
     write_host_as_little(u64, buf);
-    CHECK( buffer.substr(0, 8) == "\xef\xcd\xab\x89\x67\x45\x23\x01" );
+    CHECK(buffer.substr(0, 8) == "\xef\xcd\xab\x89\x67\x45\x23\x01");
 }
 
 TEST_CASE("native to big", "[endian][big]") {
@@ -105,61 +105,61 @@ TEST_CASE("native to big", "[endian][big]") {
     constexpr uint64_t u64_big = 0xefcdab8967452301;
 #endif
 
-    CHECK( host_to_big(u8) == u8_big );
-    CHECK( host_to_big(u16) == u16_big );
-    CHECK( host_to_big(u32) == u32_big );
-    CHECK( host_to_big(u64) == u64_big );
+    CHECK(host_to_big(u8) == u8_big);
+    CHECK(host_to_big(u16) == u16_big);
+    CHECK(host_to_big(u32) == u32_big);
+    CHECK(host_to_big(u64) == u64_big);
 
     // The above should not have mutated:
-    REQUIRE( u8 == 0x01 );
-    REQUIRE( u16 == 0x0123 );
-    REQUIRE( u32 == 0x01234567 );
-    REQUIRE( u64 == 0x0123456789abcdef );
+    REQUIRE(u8 == 0x01);
+    REQUIRE(u16 == 0x0123);
+    REQUIRE(u32 == 0x01234567);
+    REQUIRE(u64 == 0x0123456789abcdef);
 
     host_to_big_inplace(u8);
     host_to_big_inplace(u16);
     host_to_big_inplace(u32);
     host_to_big_inplace(u64);
-    CHECK( u8 == u8_big );
-    CHECK( u16 == u16_big );
-    CHECK( u32 == u32_big );
-    CHECK( u64 == u64_big );
+    CHECK(u8 == u8_big);
+    CHECK(u16 == u16_big);
+    CHECK(u32 == u32_big);
+    CHECK(u64 == u64_big);
 
-    CHECK( big_to_host(u8) == 0x01 );
-    CHECK( big_to_host(u16) == 0x0123 );
-    CHECK( big_to_host(u32) == 0x01234567 );
-    CHECK( big_to_host(u64) == 0x0123456789abcdef );
+    CHECK(big_to_host(u8) == 0x01);
+    CHECK(big_to_host(u16) == 0x0123);
+    CHECK(big_to_host(u32) == 0x01234567);
+    CHECK(big_to_host(u64) == 0x0123456789abcdef);
 
     big_to_host_inplace(u8);
     big_to_host_inplace(u16);
     big_to_host_inplace(u32);
     big_to_host_inplace(u64);
-    CHECK( u8 == 0x01 );
-    CHECK( u16 == 0x0123 );
-    CHECK( u32 == 0x01234567 );
-    CHECK( u64 == 0x0123456789abcdef );
+    CHECK(u8 == 0x01);
+    CHECK(u16 == 0x0123);
+    CHECK(u32 == 0x01234567);
+    CHECK(u64 == 0x0123456789abcdef);
 
     const char* data = "\xef\xcd\xab\x89\x67\x45\x23\x01";
-    CHECK( load_big_to_host<uint8_t>(data) == 0xef );
-    CHECK( load_big_to_host<uint16_t>(data) == 0xefcd );
-    CHECK( load_big_to_host<uint32_t>(data) == 0xefcdab89 );
-    CHECK( load_big_to_host<uint64_t>(data) == 0xefcdab8967452301 );
+    CHECK(load_big_to_host<uint8_t>(data) == 0xef);
+    CHECK(load_big_to_host<uint16_t>(data) == 0xefcd);
+    CHECK(load_big_to_host<uint32_t>(data) == 0xefcdab89);
+    CHECK(load_big_to_host<uint64_t>(data) == 0xefcdab8967452301);
 
-    CHECK( load_host_to_big<uint8_t>(data) == 0xef );
-    CHECK( load_host_to_big<uint16_t>(data) == 0xefcd );
-    CHECK( load_host_to_big<uint32_t>(data) == 0xefcdab89 );
-    CHECK( load_host_to_big<uint64_t>(data) == 0xefcdab8967452301 );
+    CHECK(load_host_to_big<uint8_t>(data) == 0xef);
+    CHECK(load_host_to_big<uint16_t>(data) == 0xefcd);
+    CHECK(load_host_to_big<uint32_t>(data) == 0xefcdab89);
+    CHECK(load_host_to_big<uint64_t>(data) == 0xefcdab8967452301);
 
     char buf[8] = {0};
     std::string_view buffer{buf, 8};
     write_host_as_big(u8, buf);
-    CHECK( buffer.substr(0, 1) == "\x01" );
+    CHECK(buffer.substr(0, 1) == "\x01");
     write_host_as_big(u16, buf);
-    CHECK( buffer.substr(0, 2) == "\x01\x23" );
+    CHECK(buffer.substr(0, 2) == "\x01\x23");
     write_host_as_big(u32, buf);
-    CHECK( buffer.substr(0, 4) == "\x01\x23\x45\x67" );
+    CHECK(buffer.substr(0, 4) == "\x01\x23\x45\x67");
     write_host_as_big(u64, buf);
-    CHECK( buffer.substr(0, 8) == "\x01\x23\x45\x67\x89\xab\xcd\xef" );
+    CHECK(buffer.substr(0, 8) == "\x01\x23\x45\x67\x89\xab\xcd\xef");
 }
 
 TEST_CASE("signed values", "[endian][signed]") {
@@ -177,12 +177,12 @@ TEST_CASE("signed values", "[endian][signed]") {
     constexpr int32_t i32_big = little_endian ? 0x67452301 : 0x01234567;
     constexpr int64_t i64_big = little_endian ? -0x1032547698badcff : 0x0123456789abcdef;
 
-    CHECK( host_to_little(i8) == i8_little );
-    CHECK( host_to_little(i16) == i16_little );
-    CHECK( host_to_little(i32) == i32_little );
-    CHECK( host_to_little(i64) == i64_little );
-    CHECK( host_to_big(i8) == i8_big );
-    CHECK( host_to_big(i16) == i16_big );
-    CHECK( host_to_big(i32) == i32_big );
-    CHECK( host_to_big(i64) == i64_big );
+    CHECK(host_to_little(i8) == i8_little);
+    CHECK(host_to_little(i16) == i16_little);
+    CHECK(host_to_little(i32) == i32_little);
+    CHECK(host_to_little(i64) == i64_little);
+    CHECK(host_to_big(i8) == i8_big);
+    CHECK(host_to_big(i16) == i16_big);
+    CHECK(host_to_big(i32) == i32_big);
+    CHECK(host_to_big(i64) == i64_big);
 }

--- a/utils/format.sh
+++ b/utils/format.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+CLANG_FORMAT_DESIRED_VERSION=15
+
+binary=$(command -v clang-format-$CLANG_FORMAT_DESIRED_VERSION 2>/dev/null)
+if [ $? -ne 0 ]; then
+    binary=$(command -v clang-format-mp-$CLANG_FORMAT_DESIRED_VERSION 2>/dev/null)
+fi
+if [ $? -ne 0 ]; then
+    binary=$(command -v clang-format 2>/dev/null)
+    if [ $? -ne 0 ]; then
+        echo "Please install clang-format version $CLANG_FORMAT_DESIRED_VERSION and re-run this script."
+        exit 1
+    fi
+    version=$(clang-format --version)
+    if [[ ! $version == *"clang-format version $CLANG_FORMAT_DESIRED_VERSION"* ]]; then
+        echo "Please install clang-format version $CLANG_FORMAT_DESIRED_VERSION and re-run this script."
+        exit 1
+    fi
+fi
+
+cd "$(dirname $0)/../"
+readarray -t sources < <(find oxenc tests | grep -E '\.([hc](pp)?)$' | grep -v '\#' | grep -v Catch2)
+if [ "$1" = "verify" ] ; then
+    if [ $($binary --output-replacements-xml "${sources[@]}"  | grep '</replacement>' | wc -l) -ne 0 ] ; then
+        exit 2
+    fi
+else
+    $binary -i "${sources[@]}" &> /dev/null
+fi
+
+jsonnet_format=$(command -v jsonnetfmt 2>/dev/null)
+if [ $? -eq 0 ]; then
+    if [ "$1" = "verify" ]; then
+        if ! $jsonnet_format --test .drone.jsonnet; then
+            exit 4
+        fi
+    else
+        $jsonnet_format --in-place .drone.jsonnet
+    fi
+fi


### PR DESCRIPTION
The current build-in-existing-buffer code is limiting in situations where you need to build something of unknown max size.

This extends bt_list_producer and bt_dict_producer so that they can work either in the existing fixed-buffer mode, but now also in a `std::string`-building mode.