### PR TITLE
Qol improvements

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -64,8 +64,8 @@ local full_llvm(version) = debian_pipeline(
 [
   debian_pipeline('Debian sid (amd64)', docker_base + 'debian-sid'),
   debian_pipeline('Debian sid/Debug (amd64)', docker_base + 'debian-sid', build_type='Debug'),
-  clang(13),
-  full_llvm(13),
+  clang(16),
+  full_llvm(16),
   debian_pipeline('Debian buster (amd64)', docker_base + 'debian-buster'),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386'),
   debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64'),

--- a/oxenc/base32z.h
+++ b/oxenc/base32z.h
@@ -152,6 +152,10 @@ std::string to_base32z(std::basic_string_view<CharT> s) {
 inline std::string to_base32z(std::string_view s) {
     return to_base32z<>(s);
 }
+template <typename CharT>
+std::string to_base32z(const std::basic_string<CharT>& s) {
+    return to_base32z(s.begin(), s.end());
+}
 
 /// Returns true if the given [begin, end) range is an acceptable base32z string: specifically every
 /// character must be in the base32z alphabet, and the string must be a valid encoding length that
@@ -307,6 +311,10 @@ std::string from_base32z(std::basic_string_view<CharT> s) {
 }
 inline std::string from_base32z(std::string_view s) {
     return from_base32z<>(s);
+}
+template <typename CharT>
+std::string from_base32z(const std::basic_string<CharT>& s) {
+    return from_base32z(s.begin(), s.end());
 }
 
 inline namespace literals {

--- a/oxenc/base64.h
+++ b/oxenc/base64.h
@@ -198,6 +198,10 @@ std::string to_base64(std::basic_string_view<CharT> s) {
 inline std::string to_base64(std::string_view s) {
     return to_base64<>(s);
 }
+template <typename CharT>
+std::string to_base64(const std::basic_string<CharT>& s) {
+    return to_base64(s.begin(), s.end());
+}
 
 /// Creates a base64 string from an iterable, std::string-like object.  The string will not be
 /// padded.
@@ -384,6 +388,10 @@ std::string from_base64(std::basic_string_view<CharT> s) {
 }
 inline std::string from_base64(std::string_view s) {
     return from_base64<>(s);
+}
+template <typename CharT>
+std::string from_base64(const std::basic_string<CharT>& s) {
+    return from_base64(s.begin(), s.end());
 }
 
 inline namespace literals {

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <charconv>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -251,6 +252,14 @@ class bt_list_producer {
         append_intermediate_ends();
     }
 
+    /// Appends an optional value: the value will be appended as if by calling `.append(*val)` if
+    /// the optional is set, and otherwise (i.e. if given nullopt) nothing is appended.
+    template <typename T>
+    void append(const std::optional<T>& val) {
+        if (val)
+            append(*val);
+    }
+
     /// Appends a sublist to this list.  Returns a new bt_list_producer that references the parent
     /// list.  The parent cannot be added to until the sublist is destroyed.  This is meant to be
     /// used via RAII:
@@ -363,6 +372,14 @@ class bt_dict_producer : bt_list_producer {
         append_impl(key);
         append_impl(value);
         append_intermediate_ends();
+    }
+
+    /// Appends a key-value pair with an optional value, *if* the optional is set.  If the value is
+    /// nullopt, nothing is appended.
+    template <typename T>
+    void append(std::string_view key, const std::optional<T>& value) {
+        if (value)
+            append(key, *value);
     }
 
     /// Appends pairs from the range [from, to) to the dict.  Elements must have a .first

--- a/oxenc/hex.h
+++ b/oxenc/hex.h
@@ -122,6 +122,10 @@ std::string to_hex(std::basic_string_view<CharT> s) {
 inline std::string to_hex(std::string_view s) {
     return to_hex<>(s);
 }
+template <typename CharT>
+std::string to_hex(const std::basic_string<CharT>& s) {
+    return to_hex(s.begin(), s.end());
+}
 
 /// Returns true if the given value is a valid hex digit.
 template <typename CharT>
@@ -260,6 +264,10 @@ std::string from_hex(std::basic_string_view<CharT> s) {
 }
 inline std::string from_hex(std::string_view s) {
     return from_hex<>(s);
+}
+template <typename CharT>
+std::string from_hex(const std::basic_string<CharT>& s) {
+    return from_hex(s.begin(), s.end());
 }
 
 inline namespace literals {


### PR DESCRIPTION
- make to_hex etc. take basic_string<T> for non-`char` T
- allow appending optional in bt_..._producer, which appends iff the value is set.