### PR TITLE
Add support for non-char basic_string/basic_string_view

### DIFF
--- a/oxenc/bt_value_producer.h
+++ b/oxenc/bt_value_producer.h
@@ -11,13 +11,16 @@ namespace oxenc {
 
 namespace detail {
 
-    void serialize_list(bt_list_producer& out, const bt_list& l);
-    void serialize_dict(bt_dict_producer& out, const bt_dict& l);
+    template <typename CharT>
+    void serialize_list(bt_list_producer<CharT>& out, const bt_list& l);
+    template <typename CharT>
+    void serialize_dict(bt_dict_producer<CharT>& out, const bt_dict& l);
 
+    template <typename CharT>
     struct dict_appender {
-        bt_dict_producer& out;
+        bt_dict_producer<CharT>& out;
         std::string_view key;
-        dict_appender(bt_dict_producer& out, std::string_view key) : out{out}, key{key} {}
+        dict_appender(bt_dict_producer<CharT>& out, std::string_view key) : out{out}, key{key} {}
 
         void operator()(const bt_dict& d) {
             auto subdict = out.append_dict(key);
@@ -33,9 +36,10 @@ namespace detail {
         }
     };
 
+    template <typename CharT>
     struct list_appender {
-        bt_list_producer& out;
-        explicit list_appender(bt_list_producer& out) : out{out} {}
+        bt_list_producer<CharT>& out;
+        explicit list_appender(bt_list_producer<CharT>& out) : out{out} {}
 
         void operator()(const bt_dict& d) {
             auto subdict = out.append_dict();
@@ -51,48 +55,50 @@ namespace detail {
         }
     };
 
-    inline void serialize_dict(bt_dict_producer& out, const bt_dict& d) {
+    template <typename CharT>
+    void serialize_dict(bt_dict_producer<CharT>& out, const bt_dict& d) {
         for (const auto& [k, v] : d)
             var::visit(dict_appender{out, k}, static_cast<const bt_variant&>(v));
     }
 
-    inline void serialize_list(bt_list_producer& out, const bt_list& l) {
+    template <typename CharT>
+    inline void serialize_list(bt_list_producer<CharT>& out, const bt_list& l) {
         for (auto& val : l)
             var::visit(list_appender{out}, static_cast<const bt_variant&>(val));
     }
 }  // namespace detail
 
-template <>
-inline void bt_list_producer::append_bt(const bt_dict& bt) {
+template <> template <>
+inline void bt_list_producer<char>::append_bt(const bt_dict& bt) {
     auto subdict = append_dict();
     detail::serialize_dict(subdict, bt);
 }
 
-template <>
-inline void bt_list_producer::append_bt(const bt_list& bt) {
+template <> template <>
+inline void bt_list_producer<char>::append_bt(const bt_list& bt) {
     auto sublist = append_list();
     detail::serialize_list(sublist, bt);
 }
 
-template <>
-inline void bt_list_producer::append_bt(const bt_value& bt) {
+template <> template <>
+inline void bt_list_producer<char>::append_bt(const bt_value& bt) {
     var::visit(detail::list_appender{*this}, static_cast<const bt_variant&>(bt));
 }
 
-template <>
-inline void bt_dict_producer::append_bt(std::string_view key, const bt_dict& bt) {
+template <> template <>
+inline void bt_dict_producer<char>::append_bt(std::string_view key, const bt_dict& bt) {
     auto subdict = append_dict(key);
     detail::serialize_dict(subdict, bt);
 }
 
-template <>
-inline void bt_dict_producer::append_bt(std::string_view key, const bt_list& bt) {
+template <> template <>
+inline void bt_dict_producer<char>::append_bt(std::string_view key, const bt_list& bt) {
     auto sublist = append_list(key);
     detail::serialize_list(sublist, bt);
 }
 
-template <>
-inline void bt_dict_producer::append_bt(std::string_view key, const bt_value& bt) {
+template <> template <>
+inline void bt_dict_producer<char>::append_bt(std::string_view key, const bt_value& bt) {
     var::visit(detail::dict_appender{*this, key}, static_cast<const bt_variant&>(bt));
 }
 }  // namespace oxenc


### PR DESCRIPTION
We currently have cases where we are using `ustring` or `bstring` (or similar views), which currently have to get converted to plain std::string_views.

On *output* we also have trouble where our dict producer is building an std::string but we need an ustring (and so have to reallocate another string and copy the bytes over).

This fixes it by templatizing bt producers and consumers to allow any size-1 char type to be used.

(WIP: needs some non-string tests added)