### PR TITLE
Non-char basic_string_view inputs and views

### DIFF
--- a/oxenc/bt_serialize.h
+++ b/oxenc/bt_serialize.h
@@ -1161,8 +1161,6 @@ class bt_dict_consumer : private bt_list_consumer {
     template <typename T>
     T require(std::string_view key) {
         required(key);
-        if (!skip_until(key))
-            throw std::out_of_range{"Key " + std::string{key} + " not found!"};
         return consume<T>();
     }
 

--- a/oxenc/bt_serialize.h
+++ b/oxenc/bt_serialize.h
@@ -729,6 +729,13 @@ class bt_list_consumer {
             throw std::runtime_error{"Cannot create a bt_list_consumer with non-list data"};
         data.remove_prefix(1);
     }
+    bt_list_consumer(std::basic_string_view<unsigned char> data_) :
+            bt_list_consumer{
+                    std::string_view{reinterpret_cast<const char*>(data_.data()), data_.size()}} {}
+    bt_list_consumer(std::basic_string_view<std::byte> data_) :
+            bt_list_consumer{
+                    std::string_view{reinterpret_cast<const char*>(data_.data()), data_.size()}} {}
+
     /// Copy constructor.  Making a copy copies the current position so can be used for multipass
     /// iteration through a list.
     bt_list_consumer(const bt_list_consumer&) = default;
@@ -754,10 +761,35 @@ class bt_list_consumer {
     /// Returns true if the next element looks like an encoded dict
     bool is_dict() const { return data.front() == 'd'; }
 
+    /// Consumes a value into the given type (string_view, string, integer, bt_dict_consumer, etc.).
+    /// This is a shortcut for calling consume_string, consume_integer, etc. based on the templated
+    /// type.
+    template <typename T>
+    T consume() {
+        if constexpr (std::is_integral_v<T>)
+            return consume_integer<T>();
+        else if constexpr (detail::is_string_like<T>)
+            return T{consume_string_view<typename T::value_type>()};
+        else if constexpr (std::is_same_v<T, bt_dict>)
+            return consume_dict();
+        else if constexpr (std::is_same_v<T, bt_list>)
+            return consume_list();
+        else if constexpr (std::is_same_v<T, bt_dict_consumer>)
+            return consume_dict_consumer();
+        else {
+            static_assert(std::is_same_v<T, bt_list_consumer>, "Unsupported consume type");
+            return consume_list_consumer();
+        }
+    }
+
     /// Attempt to parse the next value as a string (and advance just past it).  Throws if the next
     /// value is not a string.
-    std::string consume_string() { return std::string{consume_string_view()}; }
-    std::string_view consume_string_view() {
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::basic_string<Char> consume_string() {
+        return std::basic_string<Char>{consume_string_view<Char>()};
+    }
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::basic_string_view<Char> consume_string_view() {
         if (data.empty())
             throw bt_deserialize_invalid{"expected a string, but reached end of data"};
         else if (!is_string())
@@ -765,7 +797,7 @@ class bt_list_consumer {
         std::string_view next{data}, result;
         detail::bt_deserialize<std::string_view>{}(next, result);
         data = next;
-        return result;
+        return {reinterpret_cast<const Char*>(result.data()), result.size()};
     };
 
     /// Attempts to parse the next value as an integer (and advance just past it).  Throws if the
@@ -840,8 +872,9 @@ class bt_list_consumer {
     /// entire thing.  This is recursive into both lists and dicts and likely to be quite
     /// inefficient for large, nested structures (unless the values only need to be skipped but
     /// aren't separately needed).  This, however, does not require dynamic memory allocation.
-    std::string_view consume_list_data() {
-        auto orig = data;
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::basic_string_view<Char> consume_list_data() {
+        std::basic_string_view<Char> orig{reinterpret_cast<const Char*>(data.data()), data.size()};
         if (data.size() < 2 || !is_list())
             throw bt_deserialize_invalid_type{"next bt value is not a list"};
         data.remove_prefix(1);  // Descend into the sublist, consume the "l"
@@ -861,8 +894,9 @@ class bt_list_consumer {
     /// entire thing.  This is recursive into both lists and dicts and likely to be quite
     /// inefficient for large, nested structures (unless the values only need to be skipped but
     /// aren't separately needed).  This, however, does not require dynamic memory allocation.
-    std::string_view consume_dict_data() {
-        auto orig = data;
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::basic_string_view<Char> consume_dict_data() {
+        std::basic_string_view<Char> orig{reinterpret_cast<const Char*>(data.data()), data.size()};
         if (data.size() < 2 || !is_dict())
             throw bt_deserialize_invalid_type{"next bt value is not a dict"};
         data.remove_prefix(1);  // Descent into the dict, consumer the "d"
@@ -926,6 +960,12 @@ class bt_dict_consumer : private bt_list_consumer {
             throw std::runtime_error{"Cannot create a bt_dict_consumer with non-dict data"};
         data.remove_prefix(1);
     }
+    bt_dict_consumer(std::basic_string_view<unsigned char> data_) :
+            bt_dict_consumer{
+                    std::string_view{reinterpret_cast<const char*>(data_.data()), data_.size()}} {}
+    bt_dict_consumer(std::basic_string_view<std::byte> data_) :
+            bt_dict_consumer{
+                    std::string_view{reinterpret_cast<const char*>(data_.data()), data_.size()}} {}
 
     /// Copy constructor.  Making a copy copies the current position so can be used for multipass
     /// iteration through a list.
@@ -962,11 +1002,12 @@ class bt_dict_consumer : private bt_list_consumer {
 
     /// Attempt to parse the next value as a string->string pair (and advance just past it).  Throws
     /// if the next value is not a string.
-    std::pair<std::string_view, std::string_view> next_string() {
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::pair<std::string_view, std::basic_string_view<Char>> next_string() {
         if (!is_string())
             throw bt_deserialize_invalid_type{"expected a string, but found "s + data.front()};
-        std::pair<std::string_view, std::string_view> ret;
-        ret.second = bt_list_consumer::consume_string_view();
+        std::pair<std::string_view, std::basic_string_view<Char>> ret;
+        ret.second = bt_list_consumer::consume_string_view<Char>();
         ret.first = flush_key();
         return ret;
     }
@@ -1027,10 +1068,11 @@ class bt_dict_consumer : private bt_list_consumer {
     /// contains the entire thing.  This is recursive into both lists and dicts and likely to be
     /// quite inefficient for large, nested structures (unless the values only need to be skipped
     /// but aren't separately needed).  This, however, does not require dynamic memory allocation.
-    std::pair<std::string_view, std::string_view> next_list_data() {
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::pair<std::string_view, std::basic_string_view<Char>> next_list_data() {
         if (data.size() < 2 || !is_list())
             throw bt_deserialize_invalid_type{"next bt dict value is not a list"};
-        return {flush_key(), bt_list_consumer::consume_list_data()};
+        return {flush_key(), bt_list_consumer::consume_list_data<Char>()};
     }
 
     /// Same as next_list_data(), but wraps the value in a bt_list_consumer for convenience
@@ -1040,10 +1082,11 @@ class bt_dict_consumer : private bt_list_consumer {
     /// contains the entire thing.  This is recursive into both lists and dicts and likely to be
     /// quite inefficient for large, nested structures (unless the values only need to be skipped
     /// but aren't separately needed).  This, however, does not require dynamic memory allocation.
-    std::pair<std::string_view, std::string_view> next_dict_data() {
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::pair<std::string_view, std::basic_string_view<Char>> next_dict_data() {
         if (data.size() < 2 || !is_dict())
             throw bt_deserialize_invalid_type{"next bt dict value is not a dict"};
-        return {flush_key(), bt_list_consumer::consume_dict_data()};
+        return {flush_key(), bt_list_consumer::consume_dict_data<Char>()};
     }
 
     /// Same as next_dict_data(), but wraps the value in a bt_dict_consumer for convenience
@@ -1096,8 +1139,14 @@ class bt_dict_consumer : private bt_list_consumer {
     ///         value = d.consume_string();
     ///
 
-    auto consume_string_view() { return next_string().second; }
-    auto consume_string() { return std::string{consume_string_view()}; }
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    auto consume_string_view() {
+        return next_string<Char>().second;
+    }
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    auto consume_string() {
+        return std::basic_string<Char>{consume_string_view<Char>()};
+    }
 
     template <typename IntType>
     auto consume_integer() {
@@ -1124,8 +1173,14 @@ class bt_dict_consumer : private bt_list_consumer {
         next_dict(dict);
     }
 
-    std::string_view consume_list_data() { return next_list_data().second; }
-    std::string_view consume_dict_data() { return next_dict_data().second; }
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::basic_string_view<Char> consume_list_data() {
+        return next_list_data<Char>().second;
+    }
+    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    std::basic_string_view<Char> consume_dict_data() {
+        return next_dict_data<Char>().second;
+    }
 
     /// Shortcut for wrapping `consume_list_data()` in a new list consumer
     bt_list_consumer consume_list_consumer() { return consume_list_data(); }
@@ -1139,12 +1194,9 @@ class bt_dict_consumer : private bt_list_consumer {
     T consume() {
         if constexpr (std::is_integral_v<T>)
             return consume_integer<T>();
-        else if constexpr (std::is_same_v<T, std::string_view>)
-            return consume_string_view();
-        else if constexpr (detail::is_string_like<T>) {
-            auto sv = consume_string_view();
-            return T{reinterpret_cast<const typename T::value_type*>(sv.data()), sv.size()};
-        } else if constexpr (std::is_same_v<T, bt_dict>)
+        else if constexpr (detail::is_string_like<T>)
+            return T{consume_string_view<typename T::value_type>()};
+        else if constexpr (std::is_same_v<T, bt_dict>)
             return consume_dict();
         else if constexpr (std::is_same_v<T, bt_list>)
             return consume_list();

--- a/tests/test_bt.cpp
+++ b/tests/test_bt.cpp
@@ -389,7 +389,8 @@ TEST_CASE("bt_producer with non-char values", "[bt][dict][producer][char]") {
     oxenc::bt_dict_producer d;
 
     auto val = "xyz"s;
-    std::basic_string<unsigned char> val_uc{reinterpret_cast<const unsigned char*>(val.data()), val.size()};
+    std::basic_string<unsigned char> val_uc{
+            reinterpret_cast<const unsigned char*>(val.data()), val.size()};
     std::basic_string<std::byte> val_b{reinterpret_cast<const std::byte*>(val.data()), val.size()};
 
     l.append(val);
@@ -412,6 +413,54 @@ TEST_CASE("bt_producer with non-char values", "[bt][dict][producer][char]") {
     CHECK(d.view() == d_exp);
     CHECK(d.view<unsigned char>() == to_sv<unsigned char>(d_exp));
     CHECK(d.view<std::byte>() == to_sv<std::byte>(d_exp));
+}
+
+TEST_CASE("bt_consumer with non-char values", "[bt][dict][consumer][char]") {
+    auto val = "xyz"sv;
+    std::basic_string_view<unsigned char> val_uc{
+            reinterpret_cast<const unsigned char*>(val.data()), val.size()};
+    std::basic_string_view<std::byte> val_b{
+            reinterpret_cast<const std::byte*>(val.data()), val.size()};
+
+    const oxenc::bt_list_consumer l{"l3:xyze"};
+    CHECK(oxenc::bt_list_consumer{l}.consume_string_view() == val);
+    CHECK(oxenc::bt_list_consumer{l}.consume_string_view<unsigned char>() == val_uc);
+    CHECK(oxenc::bt_list_consumer{l}.consume_string_view<std::byte>() == val_b);
+    CHECK(oxenc::bt_list_consumer{l}.consume_string() == val);
+    CHECK(oxenc::bt_list_consumer{l}.consume_string<unsigned char>() == val_uc);
+    CHECK(oxenc::bt_list_consumer{l}.consume_string<std::byte>() == val_b);
+
+    CHECK(oxenc::bt_list_consumer{std::basic_string_view<unsigned char>{
+                                          reinterpret_cast<const unsigned char*>("l3:xyze")}}
+                  .consume_string() == "xyz");
+    CHECK(oxenc::bt_list_consumer{
+                  std::basic_string_view<std::byte>{reinterpret_cast<const std::byte*>("l3:xyze")}}
+                  .consume_string() == "xyz");
+
+    const oxenc::bt_dict_consumer d{"d1:a3:xyze"};
+    CHECK(oxenc::bt_dict_consumer{d}.consume_string_view() == val);
+    CHECK(oxenc::bt_dict_consumer{d}.consume_string_view<unsigned char>() == val_uc);
+    CHECK(oxenc::bt_dict_consumer{d}.consume_string_view<std::byte>() == val_b);
+    CHECK(oxenc::bt_dict_consumer{d}.consume_string() == val);
+    CHECK(oxenc::bt_dict_consumer{d}.consume_string<unsigned char>() == val_uc);
+    CHECK(oxenc::bt_dict_consumer{d}.consume_string<std::byte>() == val_b);
+
+    CHECK(oxenc::bt_dict_consumer{d}.next_string() == std::make_pair("a"sv, val));
+    CHECK(oxenc::bt_dict_consumer{d}.next_string<unsigned char>() == std::make_pair("a"sv, val_uc));
+    CHECK(oxenc::bt_dict_consumer{d}.next_string<std::byte>() == std::make_pair("a"sv, val_b));
+
+    std::basic_string_view<unsigned char> le_uc{reinterpret_cast<const unsigned char*>("le"), 2};
+    std::basic_string_view<std::byte> le_b{reinterpret_cast<const std::byte*>("le"), 2};
+    std::basic_string_view<unsigned char> de_uc{reinterpret_cast<const unsigned char*>("de"), 2};
+    std::basic_string_view<std::byte> de_b{reinterpret_cast<const std::byte*>("de"), 2};
+    CHECK(oxenc::bt_dict_consumer{"d1:alee"}.consume_list_data<unsigned char>() == le_uc);
+    CHECK(oxenc::bt_dict_consumer{"d1:alee"}.consume_list_data<std::byte>() == le_b);
+    CHECK(oxenc::bt_dict_consumer{"d1:adee"}.consume_dict_data<unsigned char>() == de_uc);
+    CHECK(oxenc::bt_dict_consumer{"d1:adee"}.consume_dict_data<std::byte>() == de_b);
+    CHECK(oxenc::bt_list_consumer{"llee"}.consume_list_data<unsigned char>() == le_uc);
+    CHECK(oxenc::bt_list_consumer{"llee"}.consume_list_data<std::byte>() == le_b);
+    CHECK(oxenc::bt_list_consumer{"ldee"}.consume_dict_data<unsigned char>() == de_uc);
+    CHECK(oxenc::bt_list_consumer{"ldee"}.consume_dict_data<std::byte>() == de_b);
 }
 
 TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {

--- a/tests/test_bt.cpp
+++ b/tests/test_bt.cpp
@@ -379,6 +379,41 @@ TEST_CASE("bt streaming dict producer", "[bt][dict][producer]") {
     }
 }
 
+template <typename Char>
+std::basic_string_view<Char> to_sv(std::string_view x) {
+    return {reinterpret_cast<const Char*>(x.data()), x.size()};
+}
+
+TEST_CASE("bt_producer with non-char values", "[bt][dict][producer][char]") {
+    oxenc::bt_list_producer l;
+    oxenc::bt_dict_producer d;
+
+    auto val = "xyz"s;
+    std::basic_string<unsigned char> val_uc{reinterpret_cast<const unsigned char*>(val.data()), val.size()};
+    std::basic_string<std::byte> val_b{reinterpret_cast<const std::byte*>(val.data()), val.size()};
+
+    l.append(val);
+    l.append(val_uc);
+    l.append(val_b);
+    l += val;
+    l += val_uc;
+    l += val_b;
+
+    d.append("a", val);
+    d.append("b", val);
+    d.append("c", val);
+
+    auto l_exp = "l3:xyz3:xyz3:xyz3:xyz3:xyz3:xyze"sv;
+    CHECK(l.view() == l_exp);
+    CHECK(l.view<unsigned char>() == to_sv<unsigned char>(l_exp));
+    CHECK(l.view<std::byte>() == to_sv<std::byte>(l_exp));
+
+    auto d_exp = "d1:a3:xyz1:b3:xyz1:c3:xyze"sv;
+    CHECK(d.view() == d_exp);
+    CHECK(d.view<unsigned char>() == to_sv<unsigned char>(d_exp));
+    CHECK(d.view<std::byte>() == to_sv<std::byte>(d_exp));
+}
+
 TEST_CASE("bt_producer/bt_value combo", "[bt][dict][value][producer]") {
 
     bt_dict_producer x;


### PR DESCRIPTION
This allows list and dict producers to accept `unsigned char` and `std::byte` basic_string_view values.

We have lots of uses where we tend to work with unsigned char or std::byte rather than plain string_view's and this makes it a lot easier to work with them.

This doesn't change anything internal: this just provides some public API wrapping around the necessary reinterpret_casts to move between those types and the internal std::string_view.