### PR TITLE
Add ethereum RLP serializer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,11 +28,12 @@ SpacesInAngles: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
-Standard: c++17
+Standard: c++20
 UseTab: Never
 SortIncludes: true
 ColumnLimit: 100
 IndentWidth: 4
+IndentRequiresClause: 'false'
 AccessModifierOffset: -2
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -99,7 +99,7 @@ local macos_pipeline(name, arch, build_type) = {
   debian_pipeline('Debian bullseye (amd64)', docker_base + 'debian-bullseye'),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386'),
   debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64'),
-  debian_pipeline('Debian stable (armhf)', docker_base + 'debian-stable/arm32v7', arch='arm64'),
+  debian_pipeline('Debian stable (armhf)', docker_base + 'debian-stable/arm32v7', arch='arm64', cmake_extra='-DCMAKE_CXX_FLAGS=-Wno-error=maybe-uninitialized'),
   debian_pipeline('Debian bullseye (armhf)', docker_base + 'debian-bullseye/arm32v7', arch='arm64'),
   debian_pipeline('Ubuntu noble (amd64)', docker_base + 'ubuntu-noble'),
   debian_pipeline('Ubuntu jammy (amd64)', docker_base + 'ubuntu-jammy'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -31,19 +31,20 @@ local debian_pipeline(name, image, arch='amd64', deps=['g++'], extra_setup=[], c
       pull: 'always',
       [if allow_fail then 'failure']: 'ignore',
       commands: [
-        'echo "Building on ${DRONE_STAGE_MACHINE}"',
-        'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
-        apt_get_quiet + 'update',
-        apt_get_quiet + 'install -y eatmydata',] + extra_setup 
-        + [
-        'eatmydata ' + apt_get_quiet + 'dist-upgrade -y',
-        'eatmydata ' + apt_get_quiet + 'install -y cmake git ninja-build pkg-config ccache ' + std.join(' ', deps),
-        'mkdir build',
-        'cd build',
-        'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always -DCMAKE_BUILD_TYPE=' + build_type + ' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ' + cmake_extra,
-        'ninja -v',
-        './tests/tests --use-colour yes',
-      ] + extra_cmds,
+                  'echo "Building on ${DRONE_STAGE_MACHINE}"',
+                  'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
+                  apt_get_quiet + 'update',
+                  apt_get_quiet + 'install -y eatmydata',
+                ] + extra_setup
+                + [
+                  'eatmydata ' + apt_get_quiet + 'dist-upgrade -y',
+                  'eatmydata ' + apt_get_quiet + 'install -y cmake git ninja-build pkg-config ccache ' + std.join(' ', deps),
+                  'mkdir build',
+                  'cd build',
+                  'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always -DCMAKE_BUILD_TYPE=' + build_type + ' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ' + cmake_extra,
+                  'ninja -v',
+                  './tests/tests --use-colour yes',
+                ] + extra_cmds,
     },
   ],
 };

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,4 +1,4 @@
-local docker_base = 'registry.oxen.rocks/lokinet-ci-';
+local docker_base = 'registry.oxen.rocks/';
 
 local submodule_commands = ['git fetch --tags', 'git submodule update --init --recursive --depth=1'];
 
@@ -69,43 +69,48 @@ local full_llvm(version) = debian_pipeline(
               ])
 );
 
+local macos_pipeline(name, arch, build_type) = {
+  kind: 'pipeline',
+  type: 'exec',
+  name: name,
+  platform: { os: 'darwin', arch: arch },
+  environment: { CLICOLOR_FORCE: '1' },  // Lets color through ninja (1.9+)
+  steps: [
+    { name: 'submodules', commands: submodule_commands },
+    {
+      name: 'build',
+      commands: [
+        'mkdir build',
+        'cd build',
+        'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fcolor-diagnostics -DCMAKE_BUILD_TYPE=' + build_type + ' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache',
+        'ninja -v',
+        './tests/tests --use-colour yes',
+      ],
+    },
+  ],
+};
+
 
 [
   debian_pipeline('Debian sid (amd64)', docker_base + 'debian-sid'),
   debian_pipeline('Debian sid/Debug (amd64)', docker_base + 'debian-sid', build_type='Debug'),
   clang(16),
   full_llvm(16),
-  debian_pipeline('Debian buster (amd64)', docker_base + 'debian-buster'),
+  debian_pipeline('Debian bullseye (amd64)', docker_base + 'debian-bullseye'),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386'),
   debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64'),
   debian_pipeline('Debian stable (armhf)', docker_base + 'debian-stable/arm32v7', arch='arm64'),
-  debian_pipeline('Debian buster (armhf)', docker_base + 'debian-buster/arm32v7', arch='arm64'),
-  debian_pipeline('Ubuntu focal (amd64)', docker_base + 'ubuntu-focal'),
-  debian_pipeline('Ubuntu bionic (amd64)',
-                  docker_base + 'ubuntu-bionic',
-                  deps=['g++-8'],
-                  extra_setup=kitware_repo('bionic'),
-                  cmake_extra='-DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8'),
-  {
-    kind: 'pipeline',
-    type: 'exec',
-    name: 'macOS (w/macports)',
-    platform: { os: 'darwin', arch: 'amd64' },
-    environment: { CLICOLOR_FORCE: '1' },  // Lets color through ninja (1.9+)
-    steps: [
-      { name: 'submodules', commands: submodule_commands },
-      {
-        name: 'build',
-        commands: [
-          'mkdir build',
-          'cd build',
-          'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fcolor-diagnostics -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache',
-          'ninja -v',
-          './tests/tests --use-colour yes',
-        ],
-      },
-    ],
-  },
+  debian_pipeline('Debian bullseye (armhf)', docker_base + 'debian-bullseye/arm32v7', arch='arm64'),
+  debian_pipeline('Ubuntu noble (amd64)', docker_base + 'ubuntu-noble'),
+  debian_pipeline('Ubuntu jammy (amd64)', docker_base + 'ubuntu-jammy'),
+  debian_pipeline('Ubuntu focal (amd64)',
+                  docker_base + 'ubuntu-focal',
+                  deps=['g++-10'],
+                  cmake_extra='-DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10'),
+  macos_pipeline('macOS (Release, Intel)', 'amd64', 'Release'),
+  macos_pipeline('macOS (Debug, Intel)', 'amd64', 'Debug'),
+  macos_pipeline('macOS (Release, ARM)', 'arm64', 'Release'),
+  macos_pipeline('macOS (Debug, ARM)', 'arm64', 'Debug'),
   {
     kind: 'pipeline',
     type: 'docker',
@@ -115,7 +120,7 @@ local full_llvm(version) = debian_pipeline(
       submodules,
       {
         name: 'build',
-        image: docker_base + 'debian-win32-cross-wine',
+        image: docker_base + 'debian-win32-cross',
         pull: 'always',
         commands: [
           'echo "Building on ${DRONE_STAGE_MACHINE}"',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 option(OXENC_BUILD_TESTS "Building and perform oxenc tests" ${oxenc_IS_TOPLEVEL_PROJECT})
 option(OXENC_BUILD_DOCS "Build oxenc documentation" ${oxenc_IS_TOPLEVEL_PROJECT})
 option(OXENC_INSTALL "Add oxenc headers to install target" ${oxenc_IS_TOPLEVEL_PROJECT})
+option(OXENC_WARNINGS_AS_ERRORS "Turn on -Werror" ${oxenc_IS_TOPLEVEL_PROJECT})
+option(OXENC_EXTRA_WARNINGS "Turn on various extra warnings" ${oxenc_IS_TOPLEVEL_PROJECT})
 
 
 configure_file(oxenc/version.h.in oxenc/version.h @ONLY)
@@ -52,6 +54,13 @@ target_include_directories(oxenc
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 add_library(oxenc::oxenc ALIAS oxenc)
+
+if(OXENC_EXTRA_WARNINGS)
+    target_compile_options(oxenc INTERFACE -Wall -Wextra -Wconversion -Wpedantic -Wcast-align -Wunused)
+endif()
+if(OXENC_WARNINGS_AS_ERRORS)
+    target_compile_options(oxenc INTERFACE -Werror)
+endif()
 
 export(
     TARGETS oxenc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(oxenc
-    VERSION 1.0.10
+    VERSION 1.0.11
     DESCRIPTION "oxenc - Base 16/32/64 and Bittorrent Encoding/Decoding Header Only Library"
     LANGUAGES CXX)
 

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <charconv>
+#include <concepts>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -10,6 +11,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "common.h"
+
 #ifndef NDEBUG
 #include "bt_serialize.h"
 #endif
@@ -17,8 +20,6 @@
 #include "variant.h"
 
 namespace oxenc {
-
-using namespace std::literals;
 
 class bt_dict_producer;
 
@@ -30,8 +31,8 @@ class bt_dict_producer;
 /// space (for int types up to 64-bit); we return a pointer one past the last char written.
 template <typename IntType>
 char* apple_to_chars10(char* buf, IntType val) {
-    static_assert(std::is_integral_v<IntType> && sizeof(IntType) <= 8);
-    if constexpr (std::is_signed_v<IntType>) {
+    static_assert(std::integral<IntType> && sizeof(IntType) <= 8);
+    if constexpr (std::signed_integral<IntType>) {
         if (val < 0) {
             buf[0] = '-';
             return apple_to_chars10(buf + 1, static_cast<std::make_unsigned_t<IntType>>(-val));
@@ -57,13 +58,7 @@ char* apple_to_chars10(char* buf, IntType val) {
 
 namespace detail {
 
-    template <typename T>
-    constexpr bool is_string_view_compatible =
-            std::is_convertible_v<T, std::string_view> ||
-            std::is_convertible_v<T, std::basic_string_view<unsigned char>> ||
-            std::is_convertible_v<T, std::basic_string_view<std::byte>>;
-
-    template <typename Char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char>
     std::string_view to_sv(const std::basic_string_view<Char>& x) {
         return {reinterpret_cast<const char*>(x.data()), x.size()};
     }
@@ -71,13 +66,13 @@ namespace detail {
     template <typename Class, typename SignFunc>
     auto append_signature_helper(Class& self, SignFunc sign) {
         using Char = std::conditional_t<
-                std::is_invocable_v<SignFunc, std::string_view&&>,
+                std::invocable<SignFunc, std::string_view&&>,
                 char,
                 std::conditional_t<
-                        std::is_invocable_v<SignFunc, std::basic_string_view<unsigned char>&&>,
+                        std::invocable<SignFunc, std::basic_string_view<unsigned char>&&>,
                         unsigned char,
                         std::conditional_t<
-                                std::is_invocable_v<SignFunc, std::basic_string_view<std::byte>&&>,
+                                std::invocable<SignFunc, std::basic_string_view<std::byte>&&>,
                                 std::byte,
                                 void>>>;
         static_assert(
@@ -87,8 +82,8 @@ namespace detail {
 
         auto result = sign(self.template view_for_signing<Char>());
         if constexpr (
-                std::is_same_v<decltype(result), char*> ||
-                std::is_same_v<decltype(result), const char*>)
+                std::same_as<decltype(result), char*> ||
+                std::same_as<decltype(result), const char*>)
             return std::string_view{result};
         else {
             static_assert(
@@ -179,9 +174,9 @@ class bt_list_producer {
 
     // Serializes an integer value and appends it to the output buffer.  Does not call
     // append_intermediate_ends().
-    template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+    template <std::integral IntType>
     void append_impl(IntType val) {
-        if constexpr (std::is_same_v<IntType, bool>)
+        if constexpr (std::same_as<IntType, bool>)
             buffer_append(val ? "i1e"sv : "i0e"sv);
         else {
             char buf[22];  // 'i' + base10 representation + 'e'
@@ -229,7 +224,7 @@ class bt_list_producer {
     /// view includes the `e` list end serialization markers which will be overwritten if the list
     /// (or an active sublist/subdict) is appended to.  Can optionally return a basic_string_view of
     /// a char-like type other than char for convenience.
-    template <typename Char = char, std::enable_if_t<sizeof(Char) == 1, int> = 0>
+    template <basic_char Char = char>
     std::basic_string_view<Char> view() const {
         const char* x;
         if (auto* s = std::get_if<std::string>(&out))
@@ -306,7 +301,7 @@ class bt_list_producer {
     }
 
     /// Appends an element containing binary string data
-    template <typename T, std::enable_if_t<detail::is_string_view_compatible<T>, int> = 0>
+    template <string_view_compatible T>
     void append(const T& data) {
         if (has_child)
             throw std::logic_error{"Cannot append to list when a sublist is active"};
@@ -314,14 +309,14 @@ class bt_list_producer {
         append_intermediate_ends();
     }
 
-    template <typename T, std::enable_if_t<detail::is_string_view_compatible<T>, int> = 0>
+    template <string_view_compatible T>
     bt_list_producer& operator+=(const T& data) {
         append(data);
         return *this;
     }
 
     /// Appends an integer (including bools)
-    template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+    template <std::integral IntType>
     void append(IntType i) {
         if (has_child)
             throw std::logic_error{"Cannot append to list when a sublist is active"};
@@ -329,7 +324,7 @@ class bt_list_producer {
         append_intermediate_ends();
     }
 
-    template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+    template <std::integral IntType>
     bt_list_producer& operator+=(IntType i) {
         append(i);
         return *this;
@@ -409,7 +404,7 @@ class bt_list_producer {
     /// Caveat emptor: this can *absolutely* be a foot-shotgun.  The rest of this class is
     /// designed such that if it *does* give you an output bt-encoded string, it *will* be
     /// valid bt-encoding.  This method violates that property.
-    template <typename T, std::enable_if_t<detail::is_string_view_compatible<T>, int> = 0>
+    template <string_view_compatible T>
     void append_encoded(T encoded) {
 #ifndef NDEBUG
         // on debug build, throw if `encoded` is invalid bt-encoded data
@@ -507,10 +502,8 @@ class bt_dict_producer : bt_list_producer {
 
     /// Appends a key-value pair with a string or integer value.  The key must be > the last key
     /// added, but this is only enforced (with an assertion) in debug builds.
-    template <
-            typename T,
-            std::enable_if_t<detail::is_string_view_compatible<T> || std::is_integral_v<T>, int> =
-                    0>
+    template <typename T>
+    requires string_view_compatible<T> || std::integral<T>
     void append(std::string_view key, const T& value) {
         if (has_child)
             throw std::logic_error{"Cannot append to list when a sublist is active"};
@@ -536,21 +529,20 @@ class bt_dict_producer : bt_list_producer {
     /// Also note that the range *must* be sorted by keys, which means either using an ordered
     /// container (e.g. std::map) or a manually ordered container (such as a vector or list of
     /// pairs).  unordered_map, however, is not acceptable.
-    template <
-            typename ForwardIt,
-            std::enable_if_t<!detail::is_string_view_compatible<ForwardIt>, int> = 0>
+    template <typename ForwardIt>
+    requires(!string_view_compatible<ForwardIt>)
     void append(ForwardIt from, ForwardIt to) {
         if (has_child)
             throw std::logic_error{"Cannot append to list when a sublist is active"};
         using KeyType = std::remove_cv_t<std::decay_t<decltype(from->first)>>;
         using ValType = std::decay_t<decltype(from->second)>;
-        static_assert(detail::is_string_view_compatible<decltype(from->first)>);
-        static_assert(detail::is_string_view_compatible<ValType> || std::is_integral_v<ValType>);
+        static_assert(string_view_compatible<decltype(from->first)>);
+        static_assert(string_view_compatible<ValType> || std::integral<ValType>);
         using BadUnorderedMap = std::unordered_map<KeyType, ValType>;
         static_assert(
                 !(  // Disallow unordered_map iterators because they are not going to be ordered.
-                        std::is_same_v<typename BadUnorderedMap::iterator, ForwardIt> ||
-                        std::is_same_v<typename BadUnorderedMap::const_iterator, ForwardIt>));
+                        std::same_as<typename BadUnorderedMap::iterator, ForwardIt> ||
+                        std::same_as<typename BadUnorderedMap::const_iterator, ForwardIt>));
         while (from != to) {
             const auto& [k, v] = *from++;
             check_incrementing_key(k);
@@ -637,7 +629,7 @@ class bt_dict_producer : bt_list_producer {
     /// Caveat emptor: this can *absolutely* be a foot-shotgun.  The rest of this class is
     /// designed such that if it *does* give you an output bt-encoded string, it *will* be
     /// valid bt-encoding.  This method violates that property.
-    template <typename T, std::enable_if_t<detail::is_string_view_compatible<T>, int> = 0>
+    template <string_view_compatible T>
     void append_encoded(std::string_view key, T encoded) {
         check_incrementing_key(key);
         append_impl(key);
@@ -665,7 +657,7 @@ inline bt_list_producer::bt_list_producer(bt_list_producer&& other) :
         throw std::logic_error{"Cannot move bt_list/dict_producer with active sublists/subdicts"};
     var::visit(
             [](auto& x) {
-                if constexpr (!std::is_same_v<output&, decltype(x)>)
+                if constexpr (!std::same_as<output&, decltype(x)>)
                     x = nullptr;
             },
             other.data);

--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -686,7 +686,7 @@ inline void bt_list_producer::buffer_append(std::string_view d) {
     } else {
         auto* bs = std::get_if<buf_span>(&out);
         assert(bs);
-        size_t avail = std::distance(bs->init + next, bs->end);
+        auto avail = static_cast<size_t>(std::distance(bs->init + next, bs->end));
         if (d.size() > avail)
             throw std::length_error{"Cannot write bt_producer: buffer size exceeded"};
         std::copy(d.begin(), d.end(), bs->init + next);

--- a/oxenc/bt_serialize.h
+++ b/oxenc/bt_serialize.h
@@ -161,7 +161,7 @@ namespace detail {
         void operator()(std::ostream& os, const std::string_view& val) {
             os << val.size();
             os.put(':');
-            os.write(val.data(), val.size());
+            os.write(val.data(), static_cast<std::streamsize>(val.size()));
         }
     };
     template <>
@@ -1426,7 +1426,7 @@ namespace detail {
         bool once = false;
         while (!s.empty() && (s[0] >= '0' && s[0] <= '9')) {
             once = true;
-            uint64_t bigger = uval * 10 + (s[0] - '0');
+            uint64_t bigger = uval * 10 + static_cast<uint64_t>(s[0] - '0');
             s.remove_prefix(1);
             if (bigger < uval)  // overflow
                 throw bt_deserialize_invalid(

--- a/oxenc/bt_serialize.h
+++ b/oxenc/bt_serialize.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <concepts>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -17,11 +18,10 @@
 #include <vector>
 
 #include "bt_value.h"
+#include "common.h"
 #include "variant.h"
 
 namespace oxenc {
-
-using namespace std::literals;
 
 /** \file
  * Oxenc serialization for internal commands is very simple: we support two primitive types,
@@ -69,17 +69,16 @@ namespace detail {
     }
 
     // Fallback base case; we only get here if none of the partial specializations below work
-    template <typename T, typename SFINAE = void>
+    template <typename T>
     struct bt_serialize {
         static_assert(
-                !std::is_same_v<T, T>, "Cannot serialize T: unsupported type for bt serialization");
+                std::is_void_v<T>, "Cannot serialize T: unsupported type for bt serialization");
     };
 
-    template <typename T, typename SFINAE = void>
+    template <typename T>
     struct bt_deserialize {
         static_assert(
-                !std::is_same_v<T, T>,
-                "Cannot deserialize T: unsupported type for bt deserialization");
+                std::is_void_v<T>, "Cannot deserialize T: unsupported type for bt deserialization");
     };
 
     /// Checks that we aren't at the end of a string view and throws if we are.
@@ -101,7 +100,8 @@ namespace detail {
 
     /// Integer specializations
     template <typename T>
-    struct bt_serialize<T, std::enable_if_t<std::is_integral_v<T>>> {
+    requires std::integral<T>
+    struct bt_serialize<T> {
         static_assert(
                 sizeof(T) <= sizeof(uint64_t),
                 "Serialization of integers larger than uint64_t is not supported");
@@ -111,20 +111,21 @@ namespace detail {
             using output_type = std::conditional_t<
                     (sizeof(T) > 1),
                     T,
-                    std::conditional_t<std::is_signed_v<T>, int, unsigned>>;
+                    std::conditional_t<std::signed_integral<T>, int, unsigned>>;
             os << 'i' << static_cast<output_type>(val) << 'e';
         }
     };
 
     template <typename T>
-    struct bt_deserialize<T, std::enable_if_t<std::is_integral_v<T>>> {
+    requires std::integral<T>
+    struct bt_deserialize<T> {
         void operator()(std::string_view& s, T& val) {
             constexpr uint64_t umax = static_cast<uint64_t>(std::numeric_limits<T>::max());
             constexpr int64_t smin = static_cast<int64_t>(std::numeric_limits<T>::min());
 
             auto [v, neg] = bt_deserialize_integer(s);
 
-            if (std::is_signed_v<T>) {
+            if (std::signed_integral<T>) {
                 if (!neg) {
                     if (v.u64 > umax)
                         throw bt_deserialize_invalid(
@@ -133,7 +134,7 @@ namespace detail {
                     val = static_cast<T>(v.u64);
                 } else {
                     auto& sval = v.i64;
-                    if (!std::is_same_v<T, int64_t> && sval < smin)
+                    if (!std::same_as<T, int64_t> && sval < smin)
                         throw bt_deserialize_invalid(
                                 "Integer deserialization failed: found too-low value " +
                                 std::to_string(sval) + " < " + std::to_string(smin));
@@ -144,7 +145,7 @@ namespace detail {
                     throw bt_deserialize_invalid(
                             "Integer deserialization failed: found negative value -" +
                             std::to_string(v.i64) + " but type is unsigned");
-                if (!std::is_same_v<T, uint64_t> && v.u64 > umax)
+                if (!std::same_as<T, uint64_t> && v.u64 > umax)
                     throw bt_deserialize_invalid(
                             "Integer deserialization failed: found too-large value " +
                             std::to_string(v.u64) + " > " + std::to_string(umax));
@@ -202,65 +203,40 @@ namespace detail {
 
     /// Partial dict validity; we don't check the second type for serializability, that will be
     /// handled via the base case static_assert if invalid.
-    template <typename T, typename = void>
-    struct is_bt_input_dict_container_impl : std::false_type {};
     template <typename T>
-    struct is_bt_input_dict_container_impl<
-            T,
-            std::enable_if_t<
-                    std::is_same_v<
-                            std::string,
-                            std::remove_cv_t<typename T::value_type::first_type>> ||
-                            std::is_same_v<
-                                    std::string_view,
-                                    std::remove_cv_t<typename T::value_type::first_type>>,
-                    std::void_t<
-                            typename T::const_iterator /* is const iterable */,
-                            typename T::value_type::second_type /* has a second type */>>>
-            : std::true_type {};
+    concept bt_input_dict_container =
+            (std::same_as<std::string, std::remove_cv_t<typename T::value_type::first_type>> ||
+             std::same_as<
+                     std::string_view,
+                     std::remove_cv_t<typename T::value_type::first_type>>)&&requires {
+                typename T::const_iterator;           // is const iterable
+                typename T::value_type::second_type;  // has a second type
+            };
 
     /// Determines whether the type looks like something we can insert into (using
     /// `v.insert(v.end(), x)`)
-    template <typename T, typename = void>
-    struct is_bt_insertable_impl : std::false_type {};
     template <typename T>
-    struct is_bt_insertable_impl<
-            T,
-            std::void_t<decltype(std::declval<T>().insert(
-                    std::declval<T>().end(), std::declval<typename T::value_type>()))>>
-            : std::true_type {};
-    template <typename T>
-    constexpr bool is_bt_insertable = is_bt_insertable_impl<T>::value;
+    concept bt_insertable =
+            requires(T v) { v.insert(v.end(), std::declval<typename T::value_type>()); };
 
     /// Determines whether the given type looks like a compatible map (i.e. has std::string keys)
     /// that we can insert into.
-    template <typename T, typename = void>
-    struct is_bt_output_dict_container_impl : std::false_type {};
     template <typename T>
-    struct is_bt_output_dict_container_impl<
-            T,
-            std::enable_if_t<
-                    std::is_same_v<
-                            std::string,
-                            std::remove_cv_t<typename T::value_type::first_type>> &&
-                            is_bt_insertable<T>,
-                    std::void_t<typename T::value_type::second_type /* has a second type */>>>
-            : std::true_type {};
-
-    template <typename T>
-    constexpr bool is_bt_output_dict_container = is_bt_output_dict_container_impl<T>::value;
-    template <typename T>
-    constexpr bool is_bt_input_dict_container = is_bt_output_dict_container_impl<T>::value;
+    concept bt_output_dict_container =
+            std::same_as<std::string, std::remove_cv_t<typename T::value_type::first_type>> &&
+            requires {
+                typename T::value_type::second_type;  // has a second type
+            };
 
     // Sanity checks:
-    static_assert(is_bt_input_dict_container<bt_dict>);
-    static_assert(is_bt_output_dict_container<bt_dict>);
+    static_assert(bt_input_dict_container<bt_dict>);
+    static_assert(bt_output_dict_container<bt_dict>);
 
     /// Specialization for a dict-like container (such as an unordered_map).  We accept anything for
     /// a dict that is const iterable over something that looks like a pair with std::string for
     /// first value type.  The value (i.e. second element of the pair) also must be serializable.
-    template <typename T>
-    struct bt_serialize<T, std::enable_if_t<is_bt_input_dict_container<T>>> {
+    template <bt_input_dict_container T>
+    struct bt_serialize<T> {
         using second_type = typename T::value_type::second_type;
         using ref_pair = std::reference_wrapper<const typename T::value_type>;
         void operator()(std::ostream& os, const T& dict) {
@@ -280,8 +256,8 @@ namespace detail {
         }
     };
 
-    template <typename T>
-    struct bt_deserialize<T, std::enable_if_t<is_bt_output_dict_container<T>>> {
+    template <bt_output_dict_container T>
+    struct bt_deserialize<T> {
         using second_type = typename T::value_type::second_type;
         void operator()(std::string_view& s, T& dict) {
             // Smallest dict is 2 bytes "de", for an empty dict.
@@ -313,38 +289,25 @@ namespace detail {
 
     /// Accept anything that looks iterable; value serialization validity isn't checked here (it
     /// fails via the base case static assert).
-    template <typename T, typename = void>
-    struct is_bt_input_list_container_impl : std::false_type {};
     template <typename T>
-    struct is_bt_input_list_container_impl<
-            T,
-            std::enable_if_t<
-                    !std::is_same_v<T, std::string> && !std::is_same_v<T, std::string_view> &&
-                            !is_bt_input_dict_container<T>,
-                    std::void_t<typename T::const_iterator, typename T::value_type>>>
-            : std::true_type {};
-
-    template <typename T, typename = void>
-    struct is_bt_output_list_container_impl : std::false_type {};
-    template <typename T>
-    struct is_bt_output_list_container_impl<
-            T,
-            std::enable_if_t<
-                    !std::is_same_v<T, std::string> && !is_bt_output_dict_container<T> &&
-                    is_bt_insertable<T>>> : std::true_type {};
+    concept bt_input_list_container =
+            !std::same_as<T, std::string> && !std::same_as<T, std::string_view> &&
+            !bt_input_dict_container<T> && requires {
+                typename T::const_iterator;
+                typename T::value_type;
+            };
 
     template <typename T>
-    constexpr bool is_bt_output_list_container = is_bt_output_list_container_impl<T>::value;
-    template <typename T>
-    constexpr bool is_bt_input_list_container = is_bt_input_list_container_impl<T>::value;
+    concept bt_output_list_container =
+            !std::same_as<T, std::string> && !bt_output_dict_container<T> && bt_insertable<T>;
 
     // Sanity checks:
-    static_assert(is_bt_input_list_container<bt_list>);
-    static_assert(is_bt_output_list_container<bt_list>);
+    static_assert(bt_input_list_container<bt_list>);
+    static_assert(bt_output_list_container<bt_list>);
 
     /// List specialization
-    template <typename T>
-    struct bt_serialize<T, std::enable_if_t<is_bt_input_list_container<T>>> {
+    template <bt_input_list_container T>
+    struct bt_serialize<T> {
         void operator()(std::ostream& os, const T& list) {
             os << 'l';
             for (const auto& v : list)
@@ -352,8 +315,8 @@ namespace detail {
             os << 'e';
         }
     };
-    template <typename T>
-    struct bt_deserialize<T, std::enable_if_t<is_bt_output_list_container<T>>> {
+    template <bt_output_list_container T>
+    struct bt_deserialize<T> {
         using value_type = typename T::value_type;
         void operator()(std::string_view& s, T& list) {
             // Smallest list is 2 bytes "le", for an empty list.
@@ -443,13 +406,13 @@ namespace detail {
     inline constexpr bool is_bt_tuple<std::pair<S, T>> = true;
 
     template <typename T>
-    constexpr bool is_bt_deserializable =
-            std::is_same_v<T, std::string> || std::is_integral_v<T> ||
-            is_bt_output_dict_container<T> || is_bt_output_list_container<T> || is_bt_tuple<T>;
+    concept bt_deserializable =
+            std::same_as<T, std::string> || std::integral<T> || bt_output_dict_container<T> ||
+            bt_output_list_container<T> || is_bt_tuple<T>;
 
     // General template and base case; this base will only actually be invoked when Ts... is empty,
     // which means we reached the end without finding any variant type capable of holding the value.
-    template <typename SFINAE, typename Variant, typename... Ts>
+    template <typename Variant, typename... Ts>
     struct bt_deserialize_try_variant_impl {
         void operator()(std::string_view&, Variant&) {
             throw bt_deserialize_invalid(
@@ -459,22 +422,18 @@ namespace detail {
 
     template <typename... Ts, typename Variant>
     void bt_deserialize_try_variant(std::string_view& s, Variant& variant) {
-        bt_deserialize_try_variant_impl<void, Variant, Ts...>{}(s, variant);
+        bt_deserialize_try_variant_impl<Variant, Ts...>{}(s, variant);
     }
 
-    template <typename Variant, typename T, typename... Ts>
-    struct bt_deserialize_try_variant_impl<
-            std::enable_if_t<is_bt_deserializable<T>>,
-            Variant,
-            T,
-            Ts...> {
+    template <typename Variant, bt_deserializable T, typename... Ts>
+    struct bt_deserialize_try_variant_impl<Variant, T, Ts...> {
         void operator()(std::string_view& s, Variant& variant) {
-            if (is_bt_output_list_container<T>   ? s[0] == 'l'
-                : is_bt_tuple<T>                 ? s[0] == 'l'
-                : is_bt_output_dict_container<T> ? s[0] == 'd'
-                : std::is_integral_v<T>          ? s[0] == 'i'
-                : std::is_same_v<T, std::string> ? s[0] >= '0' && s[0] <= '9'
-                                                 : false) {
+            if (bt_output_list_container<T>    ? s[0] == 'l'
+                : is_bt_tuple<T>               ? s[0] == 'l'
+                : bt_output_dict_container<T>  ? s[0] == 'd'
+                : std::integral<T>             ? s[0] == 'i'
+                : std::same_as<T, std::string> ? s[0] >= '0' && s[0] <= '9'
+                                               : false) {
                 T val;
                 bt_deserialize<T>{}(s, val);
                 variant = std::move(val);
@@ -485,11 +444,8 @@ namespace detail {
     };
 
     template <typename Variant, typename T, typename... Ts>
-    struct bt_deserialize_try_variant_impl<
-            std::enable_if_t<!is_bt_deserializable<T>>,
-            Variant,
-            T,
-            Ts...> {
+    requires(!bt_deserializable<T>)
+    struct bt_deserialize_try_variant_impl<Variant, T, Ts...> {
         void operator()(std::string_view& s, Variant& variant) {
             // Unsupported deserialization type, skip it
             bt_deserialize_try_variant<Ts...>(s, variant);
@@ -498,11 +454,15 @@ namespace detail {
 
     // Serialization of a variant; all variant types must be bt-serializable.
     template <typename... Ts>
-    struct bt_serialize<std::variant<Ts...>, std::void_t<bt_serialize<Ts>...>> {
+    struct bt_serialize<std::variant<Ts...>> {
+        static_assert(
+                (std::invocable<bt_serialize<Ts>, std::ostream&, const Ts&> && ...),
+                "all variant types must be bt-serializable");
+
         void operator()(std::ostream& os, const std::variant<Ts...>& val) {
             var::visit(
                     [&os](const auto& val) {
-                        using T = std::remove_cv_t<std::remove_reference_t<decltype(val)>>;
+                        using T = std::remove_cvref_t<decltype(val)>;
                         bt_serialize<T>{}(os, val);
                     },
                     val);
@@ -511,9 +471,10 @@ namespace detail {
 
     // Deserialization to a variant; at least one variant type must be bt-deserializble.
     template <typename... Ts>
-    struct bt_deserialize<
-            std::variant<Ts...>,
-            std::enable_if_t<(is_bt_deserializable<Ts> || ...)>> {
+    struct bt_deserialize<std::variant<Ts...>> {
+        static_assert(
+                (bt_deserializable<Ts> || ...), "at least one type must be bt-deserializable");
+
         void operator()(std::string_view& s, std::variant<Ts...>& val) {
             bt_deserialize_try_variant<Ts...>(s, val);
         }
@@ -601,12 +562,14 @@ std::string bt_serialize(const T& val) {
 /// Note that this method can set a value even if in fails, in particular when the value was parsed
 /// successfully but the parsed string still has remaining content.
 ///
-template <typename T, std::enable_if_t<!std::is_const_v<T>, int> = 0>
+template <typename T>
+requires(!std::is_const_v<T>)
 void bt_deserialize(std::string_view s, T& val) {
     detail::bt_deserialize<T>{}(s, val);
     if (!s.empty())
         throw bt_deserialize_invalid{
-                "Deserialization failed: did not consume the entire encoded string" + std::to_string(s.size())};
+                "Deserialization failed: did not consume the entire encoded string" +
+                std::to_string(s.size())};
 }
 
 /// Deserializes the given string_view into a `T`, which is returned.
@@ -644,10 +607,10 @@ inline bt_value bt_get(std::string_view s) {
 ///     std::string encoded = "i123456789e";
 ///     auto val = bt_get(encoded);
 ///     auto v = get_int<uint32_t>(val); // throws if the decoded value doesn't fit in a uint32_t
-template <typename IntType, std::enable_if_t<std::is_integral_v<IntType>, int> = 0>
+template <std::integral IntType>
 IntType get_int(const bt_value& v) {
     if (auto* value = std::get_if<uint64_t>(&v)) {
-        if constexpr (!std::is_same_v<IntType, uint64_t>)
+        if constexpr (!std::same_as<IntType, uint64_t>)
             if (*value > static_cast<uint64_t>(std::numeric_limits<IntType>::max()))
                 throw std::overflow_error(
                         "Unable to extract integer value: stored value is too large for the "
@@ -656,7 +619,7 @@ IntType get_int(const bt_value& v) {
     }
 
     int64_t value = var::get<int64_t>(v);  // throws if no int contained
-    if constexpr (!std::is_same_v<IntType, int64_t>)
+    if constexpr (!std::same_as<IntType, int64_t>)
         if (value > static_cast<int64_t>(std::numeric_limits<IntType>::max()) ||
             value < static_cast<int64_t>(std::numeric_limits<IntType>::min()))
             throw std::overflow_error(
@@ -692,15 +655,14 @@ namespace detail {
     template <typename T, typename It>
     void get_tuple_impl_one(T& t, It& it) {
         const bt_variant& v = *it++;
-        if constexpr (std::is_integral_v<T>) {
+        if constexpr (std::integral<T>) {
             t = oxenc::get_int<T>(v);
         } else if constexpr (is_bt_tuple<T>) {
             if (std::holds_alternative<bt_list>(v))
                 throw std::invalid_argument{
                         "Unable to convert tuple: cannot create sub-tuple from non-bt_list"};
             t = get_tuple<T>(var::get<bt_list>(v));
-        } else if constexpr (
-                std::is_same_v<std::string, T> || std::is_same_v<std::string_view, T>) {
+        } else if constexpr (std::same_as<std::string, T> || std::same_as<std::string_view, T>) {
             // If we request a string/string_view, we might have the other one and need to copy/view
             // it.
             if (std::holds_alternative<std::string_view>(v))
@@ -721,18 +683,18 @@ namespace detail {
 
     template <typename T, typename Consumer>
     T consume_impl(Consumer& c) {
-        if constexpr (std::is_integral_v<T>)
+        if constexpr (std::integral<T>)
             return c.template consume_integer<T>();
         else if constexpr (detail::is_string_like<T>)
             return T{c.template consume_string_view<typename T::value_type>()};
-        else if constexpr (std::is_same_v<T, bt_dict>)
+        else if constexpr (std::same_as<T, bt_dict>)
             return c.consume_dict();
-        else if constexpr (std::is_same_v<T, bt_list>)
+        else if constexpr (std::same_as<T, bt_list>)
             return c.consume_list();
-        else if constexpr (std::is_same_v<T, bt_dict_consumer>)
+        else if constexpr (std::same_as<T, bt_dict_consumer>)
             return c.consume_dict_consumer();
         else {
-            static_assert(std::is_same_v<T, bt_list_consumer>, "Unsupported consume type");
+            static_assert(std::same_as<T, bt_list_consumer>, "Unsupported consume type");
             return c.consume_list_consumer();
         }
     }
@@ -799,11 +761,11 @@ class bt_list_consumer {
 
     /// Attempt to parse the next value as a string (and advance just past it).  Throws if the next
     /// value is not a string.
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::basic_string<Char> consume_string() {
         return std::basic_string<Char>{consume_string_view<Char>()};
     }
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::basic_string_view<Char> consume_string_view() {
         if (data.empty())
             throw bt_deserialize_invalid{"expected a string, but reached end of data"};
@@ -873,7 +835,7 @@ class bt_list_consumer {
     /// entire thing.  This is recursive into both lists and dicts and likely to be quite
     /// inefficient for large, nested structures (unless the values only need to be skipped but
     /// aren't separately needed).  This, however, does not require dynamic memory allocation.
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::basic_string_view<Char> consume_list_data() {
         std::basic_string_view<Char> orig{reinterpret_cast<const Char*>(data.data()), data.size()};
         if (data.size() < 2 || !is_list())
@@ -895,7 +857,7 @@ class bt_list_consumer {
     /// entire thing.  This is recursive into both lists and dicts and likely to be quite
     /// inefficient for large, nested structures (unless the values only need to be skipped but
     /// aren't separately needed).  This, however, does not require dynamic memory allocation.
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::basic_string_view<Char> consume_dict_data() {
         std::basic_string_view<Char> orig{reinterpret_cast<const Char*>(data.data()), data.size()};
         if (data.size() < 2 || !is_dict())
@@ -936,16 +898,16 @@ class bt_list_consumer {
     template <typename VerifyFunc>
     void consume_signature(VerifyFunc verify) {
         using Char = std::conditional_t<
-                std::is_invocable_v<VerifyFunc, std::string_view&&, std::string_view&&>,
+                std::invocable<VerifyFunc, std::string_view&&, std::string_view&&>,
                 char,
                 std::conditional_t<
-                        std::is_invocable_v<
+                        std::invocable<
                                 VerifyFunc,
                                 std::basic_string_view<unsigned char>&&,
                                 std::basic_string_view<unsigned char>&&>,
                         unsigned char,
                         std::conditional_t<
-                                std::is_invocable_v<
+                                std::invocable<
                                         VerifyFunc,
                                         std::basic_string_view<std::byte>&&,
                                         std::basic_string_view<std::byte>&&>,
@@ -1079,7 +1041,7 @@ class bt_dict_consumer : private bt_list_consumer {
 
     /// Attempt to parse the next value as a string->string pair (and advance just past it).  Throws
     /// if the next value is not a string.
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::pair<std::string_view, std::basic_string_view<Char>> next_string() {
         if (!is_string())
             throw bt_deserialize_invalid_type{"expected a string, but found "s + data.front()};
@@ -1145,7 +1107,7 @@ class bt_dict_consumer : private bt_list_consumer {
     /// contains the entire thing.  This is recursive into both lists and dicts and likely to be
     /// quite inefficient for large, nested structures (unless the values only need to be skipped
     /// but aren't separately needed).  This, however, does not require dynamic memory allocation.
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::pair<std::string_view, std::basic_string_view<Char>> next_list_data() {
         if (data.size() < 2 || !is_list())
             throw bt_deserialize_invalid_type{"next bt dict value is not a list"};
@@ -1159,7 +1121,7 @@ class bt_dict_consumer : private bt_list_consumer {
     /// contains the entire thing.  This is recursive into both lists and dicts and likely to be
     /// quite inefficient for large, nested structures (unless the values only need to be skipped
     /// but aren't separately needed).  This, however, does not require dynamic memory allocation.
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::pair<std::string_view, std::basic_string_view<Char>> next_dict_data() {
         if (data.size() < 2 || !is_dict())
             throw bt_deserialize_invalid_type{"next bt dict value is not a dict"};
@@ -1262,11 +1224,11 @@ class bt_dict_consumer : private bt_list_consumer {
     ///         value = d.consume_string();
     ///
 
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     auto consume_string_view() {
         return next_string<Char>().second;
     }
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     auto consume_string() {
         return std::basic_string<Char>{consume_string_view<Char>()};
     }
@@ -1296,11 +1258,11 @@ class bt_dict_consumer : private bt_list_consumer {
         next_dict(dict);
     }
 
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::basic_string_view<Char> consume_list_data() {
         return next_list_data<Char>().second;
     }
-    template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+    template <basic_char Char = char>
     std::basic_string_view<Char> consume_dict_data() {
         return next_dict_data<Char>().second;
     }
@@ -1333,16 +1295,16 @@ class bt_dict_consumer : private bt_list_consumer {
     template <typename VerifyFunc>
     void consume_signature(VerifyFunc verify) {
         using Char = std::conditional_t<
-                std::is_invocable_v<VerifyFunc, std::string_view, std::string_view>,
+                std::invocable<VerifyFunc, std::string_view, std::string_view>,
                 char,
                 std::conditional_t<
-                        std::is_invocable_v<
+                        std::invocable<
                                 VerifyFunc,
                                 std::basic_string_view<unsigned char>,
                                 std::basic_string_view<unsigned char>>,
                         unsigned char,
                         std::conditional_t<
-                                std::is_invocable_v<
+                                std::invocable<
                                         VerifyFunc,
                                         std::basic_string_view<std::byte>,
                                         std::basic_string_view<std::byte>>,
@@ -1509,7 +1471,7 @@ namespace detail {
     template struct bt_deserialize<int64_t>;
     template struct bt_deserialize<uint64_t>;
 
-    inline void bt_deserialize<bt_value, void>::operator()(std::string_view& s, bt_value& val) {
+    inline void bt_deserialize<bt_value>::operator()(std::string_view& s, bt_value& val) {
         if (s.size() < 2)
             throw bt_deserialize_invalid(
                     "Deserialization failed: end of string found where bt-encoded value expected");

--- a/oxenc/bt_value.h
+++ b/oxenc/bt_value.h
@@ -65,13 +65,13 @@ struct bt_value : bt_variant {
             typename T,
             typename U = std::remove_reference_t<T>,
             std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
-    bt_value(T&& uint) : bt_variant{static_cast<uint64_t>(uint)} {}
+    bt_value(T&& u_val) : bt_variant{static_cast<uint64_t>(u_val)} {}
 
     template <
             typename T,
             typename U = std::remove_reference_t<T>,
             std::enable_if_t<std::is_integral_v<U> && std::is_signed_v<U>, int> = 0>
-    bt_value(T&& sint) : bt_variant{static_cast<int64_t>(sint)} {}
+    bt_value(T&& s_val) : bt_variant{static_cast<int64_t>(s_val)} {}
 
     template <typename... T>
     bt_value(const std::tuple<T...>& tuple) :

--- a/oxenc/common.h
+++ b/oxenc/common.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <concepts>
+#include <iterator>
+#include <string_view>
+#include <type_traits>
+
+namespace oxenc {
+
+template <typename T>
+concept string_view_compatible = std::convertible_to<T, std::string_view> ||
+                                 std::convertible_to<T, std::basic_string_view<unsigned char>> ||
+                                 std::convertible_to<T, std::basic_string_view<std::byte>>;
+
+template <typename Char>
+concept basic_char = sizeof(Char) == 1 && !std::same_as<Char, bool> &&
+                     (std::integral<Char> || std::same_as<Char, std::byte>);
+
+using namespace std::literals;
+
+}  // namespace oxenc

--- a/oxenc/endian.h
+++ b/oxenc/endian.h
@@ -61,11 +61,11 @@ constexpr bool is_endian_swappable = std::is_integral_v<T> && (sizeof(T) == 1 ||
 template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
 void byteswap_inplace(T& val) {
     if constexpr (sizeof(T) == 2)
-        val = bswap_16(val);
+        val = static_cast<T>(bswap_16(static_cast<uint16_t>(val)));
     else if constexpr (sizeof(T) == 4)
-        val = bswap_32(val);
+        val = static_cast<T>(bswap_32(static_cast<uint32_t>(val)));
     else if constexpr (sizeof(T) == 8)
-        val = bswap_64(val);
+        val = static_cast<T>(bswap_64(static_cast<uint64_t>(val)));
 }
 
 /// Converts a host-order integer value into a little-endian value, mutating it.  Does nothing

--- a/oxenc/endian.h
+++ b/oxenc/endian.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <bit>
+#include <concepts>
 #include <cstdint>
 #include <cstring>
-#include <type_traits>
 
 #if defined(_MSC_VER) && (!defined(__clang__) || defined(__c2__))
 #include <cstdlib>
@@ -25,40 +26,20 @@ extern "C" {
 namespace oxenc {
 
 /// True if this is a little-endian platform
-inline constexpr bool little_endian =
-#if defined(__LITTLE_ENDIAN__)
-        true
-#elif defined(__BIG_ENDIAN__)
-        false
-#elif defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN
-        true
-#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-        __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-        true
-#elif defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN
-        false
-#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-        __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        false
-#elif defined(_WIN32)
-        true
-#else
-#error "Error: don't know which endian this is"
-#endif
-        ;
+inline constexpr bool little_endian = std::endian::native == std::endian::little;
 
 /// True if this is a big-endian platform
 inline constexpr bool big_endian = !little_endian;
 
-/// True if the type is integral and of a size we support swapping.  (We also allow size-1
+/// True if the type is integral and of a size we support swapping.  (We also allow size=1
 /// values to be passed here for completeness, though nothing is ever swapped for such a value).
 template <typename T>
-constexpr bool is_endian_swappable = std::is_integral_v<T> && (sizeof(T) == 1 || sizeof(T) == 2 ||
-                                                               sizeof(T) == 4 || sizeof(T) == 8);
+concept endian_swappable_integer =
+        std::integral<T> && (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
 
 /// Byte swaps an integer value unconditionally.  You usually want to use one of the other
 /// endian-aware functions rather than this.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void byteswap_inplace(T& val) {
     if constexpr (sizeof(T) == 2)
         val = static_cast<T>(bswap_16(static_cast<uint16_t>(val)));
@@ -70,7 +51,7 @@ void byteswap_inplace(T& val) {
 
 /// Converts a host-order integer value into a little-endian value, mutating it.  Does nothing
 /// on little-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void host_to_little_inplace(T& val) {
     if constexpr (!little_endian)
         byteswap_inplace(val);
@@ -78,7 +59,7 @@ void host_to_little_inplace(T& val) {
 
 /// Converts a host-order integer value into a little-endian value, returning it.  Does no
 /// converstion on little-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T host_to_little(T val) {
     host_to_little_inplace(val);
     return val;
@@ -86,7 +67,7 @@ T host_to_little(T val) {
 
 /// Converts a little-endian integer value into a host-order (native) integer value, mutating
 /// it.  Does nothing on little-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void little_to_host_inplace(T& val) {
     if constexpr (!little_endian)
         byteswap_inplace(val);
@@ -94,7 +75,7 @@ void little_to_host_inplace(T& val) {
 
 /// Converts a little-order integer value into a host-order (native) integer value, returning
 /// it.  Does no conversion on little-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T little_to_host(T val) {
     little_to_host_inplace(val);
     return val;
@@ -102,7 +83,7 @@ T little_to_host(T val) {
 
 /// Converts a host-order integer value into a big-endian value, mutating it.  Does nothing on
 /// big-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void host_to_big_inplace(T& val) {
     if constexpr (!big_endian)
         byteswap_inplace(val);
@@ -110,7 +91,7 @@ void host_to_big_inplace(T& val) {
 
 /// Converts a host-order integer value into a big-endian value, returning it.  Does no
 /// conversion on big-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T host_to_big(T val) {
     host_to_big_inplace(val);
     return val;
@@ -118,7 +99,7 @@ T host_to_big(T val) {
 
 /// Converts a big-endian value into a host-order (native) integer value, mutating it.  Does
 /// nothing on big-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void big_to_host_inplace(T& val) {
     if constexpr (!big_endian)
         byteswap_inplace(val);
@@ -126,7 +107,7 @@ void big_to_host_inplace(T& val) {
 
 /// Converts a big-order integer value into a host-order (native) integer value, returning it.
 /// Does no conversion on big-endian platforms.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T big_to_host(T val) {
     big_to_host_inplace(val);
     return val;
@@ -134,7 +115,7 @@ T big_to_host(T val) {
 
 /// Loads a host-order integer value from a memory location containing little-endian bytes.
 /// (There is no alignment requirement on the given pointer address).
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T load_little_to_host(const void* from) {
     T val;
     std::memcpy(&val, from, sizeof(T));
@@ -144,7 +125,7 @@ T load_little_to_host(const void* from) {
 
 /// Loads a little-endian integer value from a memory location containing host order bytes.
 /// (There is no alignment requirement on the given pointer address).
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T load_host_to_little(const void* from) {
     T val;
     std::memcpy(&val, from, sizeof(T));
@@ -154,7 +135,7 @@ T load_host_to_little(const void* from) {
 
 /// Loads a host-order integer value from a memory location containing big-endian bytes.  (There
 /// is no alignment requirement on the given pointer address).
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T load_big_to_host(const void* from) {
     T val;
     std::memcpy(&val, from, sizeof(T));
@@ -164,7 +145,7 @@ T load_big_to_host(const void* from) {
 
 /// Loads a big-endian integer value from a memory location containing host order bytes.  (There
 /// is no alignment requirement on the given pointer address).
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 T load_host_to_big(const void* from) {
     T val;
     std::memcpy(&val, from, sizeof(T));
@@ -174,7 +155,7 @@ T load_host_to_big(const void* from) {
 
 /// Writes a little-endian integer value into the given memory location, copying and converting
 /// it (if necessary) from the given host-order integer value.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void write_host_as_little(T val, void* to) {
     host_to_little_inplace(val);
     std::memcpy(to, &val, sizeof(T));
@@ -182,7 +163,7 @@ void write_host_as_little(T val, void* to) {
 
 /// Writes a big-endian integer value into the given memory location, copying and converting it
 /// (if necessary) from the given host-order integer value.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void write_host_as_big(T val, void* to) {
     host_to_big_inplace(val);
     std::memcpy(to, &val, sizeof(T));
@@ -190,7 +171,7 @@ void write_host_as_big(T val, void* to) {
 
 /// Writes a host-order integer value into the given memory location, copying and converting it
 /// (if necessary) from the given little-endian integer value.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void write_little_as_host(T val, void* to) {
     little_to_host_inplace(val);
     std::memcpy(to, &val, sizeof(T));
@@ -198,7 +179,7 @@ void write_little_as_host(T val, void* to) {
 
 /// Writes a host-order integer value into the given memory location, copying and converting it
 /// (if necessary) from the given big-endian integer value.
-template <typename T, typename = std::enable_if_t<is_endian_swappable<T>>>
+template <endian_swappable_integer T>
 void write_big_as_host(T val, void* to) {
     big_to_host_inplace(val);
     std::memcpy(to, &val, sizeof(T));

--- a/oxenc/hex.h
+++ b/oxenc/hex.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <array>
 #include <cassert>
 #include <cstdint>
 #include <iterator>
@@ -18,14 +17,14 @@ namespace detail {
         char from_hex_lut[256];
         char to_hex_lut[16];
         constexpr hex_table() noexcept : from_hex_lut{}, to_hex_lut{} {
-            for (unsigned char c = 0; c < 10; c++) {
-                from_hex_lut[(unsigned char)('0' + c)] = static_cast<char>(0 + c);
-                to_hex_lut[(unsigned char)(0 + c)] = static_cast<char>('0' + c);
+            for (char c = 0; c < 10; c++) {
+                from_hex_lut['0' + c] = static_cast<char>(0 + c);
+                to_hex_lut[0 + c] = static_cast<char>('0' + c);
             }
-            for (unsigned char c = 0; c < 6; c++) {
-                from_hex_lut[(unsigned char)('a' + c)] = static_cast<char>(10 + c);
-                from_hex_lut[(unsigned char)('A' + c)] = static_cast<char>(10 + c);
-                to_hex_lut[(unsigned char)(10 + c)] = static_cast<char>('a' + c);
+            for (char c = 0; c < 6; c++) {
+                from_hex_lut['a' + c] = static_cast<char>(10 + c);
+                from_hex_lut['A' + c] = static_cast<char>(10 + c);
+                to_hex_lut[10 + c] = static_cast<char>('a' + c);
             }
         }
         constexpr char from_hex(unsigned char c) const noexcept { return from_hex_lut[c]; }
@@ -108,7 +107,7 @@ std::string to_hex(It begin, It end) {
                           std::random_access_iterator_tag,
                           typename std::iterator_traits<It>::iterator_category>) {
         using std::distance;
-        hex.reserve(to_hex_size(distance(begin, end)));
+        hex.reserve(to_hex_size(static_cast<size_t>(distance(begin, end))));
     }
     to_hex(begin, end, std::back_inserter(hex));
     return hex;
@@ -250,7 +249,7 @@ std::string from_hex(It begin, It end) {
                           std::random_access_iterator_tag,
                           typename std::iterator_traits<It>::iterator_category>) {
         using std::distance;
-        bytes.reserve(from_hex_size(distance(begin, end)));
+        bytes.reserve(from_hex_size(static_cast<size_t>(distance(begin, end))));
     }
     from_hex(begin, end, std::back_inserter(bytes));
     return bytes;

--- a/oxenc/rlp_serialize.h
+++ b/oxenc/rlp_serialize.h
@@ -30,7 +30,7 @@ struct rlp_value : rlp_variant {
             typename T,
             typename U = std::remove_reference_t<T>,
             std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
-    rlp_value(T&& uint) : rlp_variant{static_cast<uint64_t>(uint)} {}
+    rlp_value(T&& val) : rlp_variant{static_cast<uint64_t>(val)} {}
 
     template <
             typename T,
@@ -163,12 +163,12 @@ namespace detail {
         std::string result;
         if (payload.size() <= 55) {
             result.reserve(1 + payload.size());
-            result.push_back(base_code + payload.size());
+            result.push_back(static_cast<char>(base_code + payload.size()));
         } else {
 
             auto [buf, length] = rlp_encode_integer(payload.size());
             result.reserve(1 + length.size() + payload.size());
-            result.push_back(base_code + 55 + length.size());
+            result.push_back(static_cast<char>(base_code + 55 + length.size()));
             result += length;
         }
         result += payload;

--- a/oxenc/rlp_serialize.h
+++ b/oxenc/rlp_serialize.h
@@ -1,0 +1,179 @@
+#include <array>
+#include <cstddef>
+#include <list>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "endian.h"
+
+namespace oxenc {
+
+// Basic types to help construct an RLP-serializable, recursive value.  These do *not* have to be
+// used: you can pass ordinary C++ types (e.g. vectors of strings, etc.); these types are here to
+// allow for arbitrary value encoding, including nesting.
+struct rlp_value;
+// List of RLP-serializable values:
+using rlp_list = std::list<rlp_value>;
+// Variant of any RLP-serializable value:
+using rlp_variant = std::variant<std::string, std::string_view, uint64_t, rlp_list>;
+
+// rlp_value is just the variant, but by using inheritance and a forward declaration we can make it
+// recursive.
+struct rlp_value : rlp_variant {
+    using rlp_variant::rlp_variant;
+    using rlp_variant::operator=;
+
+    template <
+            typename T,
+            typename U = std::remove_reference_t<T>,
+            std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
+    rlp_value(T&& uint) : rlp_variant{static_cast<uint64_t>(uint)} {}
+
+    template <
+            typename T,
+            typename U = std::remove_reference_t<T>,
+            std::enable_if_t<!std::is_integral_v<U>, int> = 0>
+    rlp_value(T&& v) : rlp_variant{std::forward<T>(v)} {}
+
+    rlp_value(const char* s) : rlp_value{std::string_view{s}} {}
+};
+
+namespace detail {
+    template <typename T, typename = void>
+    constexpr bool is_rlp_serializable = false;
+
+    template <typename T>
+    constexpr bool
+            is_rlp_serializable<T, std::enable_if_t<std::is_unsigned_v<std::remove_cvref_t<T>>>> =
+                    true;
+
+    template <typename T>
+    constexpr bool is_span = false;
+    template <typename T>
+    constexpr bool is_span<std::span<T>> = true;
+    template <typename T>
+    constexpr bool is_basic_char =
+            sizeof(T) == 1 && (std::is_integral_v<T> || std::is_same_v<T, std::byte>);
+    template <typename T>
+    constexpr bool is_char_span = false;
+    template <typename T>
+    constexpr bool is_char_span<std::span<T>> = is_basic_char<std::remove_cv_t<T>>;
+    template <typename T, typename = void>
+    constexpr bool is_span_convertible = false;
+    template <typename T>
+    constexpr bool is_span_convertible<
+            T,
+            std::enable_if_t<
+                    !is_span<T> &&
+                    std::is_convertible_v<const T&, std::span<const typename T::value_type>>>> =
+            true;
+
+    template <typename T>
+    constexpr bool is_list = false;
+    template <typename T>
+    constexpr bool is_list<std::list<T>> = true;
+
+    template <typename T>
+    constexpr bool is_rlp_serializable<T, std::enable_if_t<is_span_convertible<T>>> =
+            is_rlp_serializable<std::span<const typename T::value_type>>;
+
+    template <typename T>
+    constexpr bool is_rlp_serializable<std::span<T>> =
+            is_char_span<std::span<T>> || is_rlp_serializable<std::remove_cvref_t<T>>;
+
+    template <typename T>
+    constexpr bool is_rlp_serializable<std::list<T>> = is_rlp_serializable<std::remove_cvref_t<T>>;
+
+    template <typename... Ts>
+    constexpr bool is_rlp_serializable<std::variant<Ts...>> =
+            (is_rlp_serializable<std::remove_cvref_t<Ts>> && ...);
+
+    template <>
+    inline constexpr bool is_rlp_serializable<rlp_value> = true;
+
+    template <typename... T>
+    constexpr bool is_variant = false;
+    template <typename... T>
+    constexpr bool is_variant<std::variant<T...>> = true;
+
+    template <typename T>
+    std::pair<std::array<char, sizeof(T)>, std::string_view> rlp_encode_integer(const T& val) {
+        std::pair<std::array<char, sizeof(T)>, std::string_view> result;
+        auto& [buf, length] = result;
+        oxenc::write_host_as_big(val, buf.data());
+        length = {buf.data(), buf.size()};
+        while (!length.empty() && length[0] == 0)
+            length.remove_prefix(1);
+        return result;
+    }
+    std::string rlp_encode_payload(std::string_view payload, unsigned char base_code);
+
+}  // namespace detail
+
+template <typename T>
+concept RLPSerializable = detail::is_rlp_serializable<T>;
+
+/// Does rlp serialization of a serializable spannable container, string value, or unsigned integer
+/// value.  If the container contains single-byte types (like a std::string, string_view, or even
+/// std::vector<uint8_t>) then the value is interpreted as a string to be encoded.  (If you need to
+/// pass a list of small values, use a larger integer type).
+///
+/// Also takes a variant of serializable types, and containers can recursively contain other
+/// serializable types.
+template <RLPSerializable T>
+inline std::string rlp_serialize(const T& val) {
+    using namespace detail;
+
+    if constexpr (std::is_unsigned_v<T>) {
+        auto [buf, v] = rlp_encode_integer(val);
+        return rlp_serialize(v);
+    } else if constexpr (is_char_span<T>) {
+        std::string_view str{reinterpret_cast<const char*>(val.data()), val.size()};
+        if (str.size() == 1 && static_cast<unsigned char>(str[0]) < 0x80)
+            return std::string{str};
+        return detail::rlp_encode_payload(str, 0x80u);
+    } else if constexpr (is_span<T> || is_list<T>) {
+        std::string payload;
+        for (const auto& x : val)
+            payload += rlp_serialize(x);
+        return detail::rlp_encode_payload(payload, 0xc0u);
+    } else if constexpr (is_span_convertible<T>) {
+        std::span<const typename T::value_type> span = val;
+        return rlp_serialize(span);
+    } else if constexpr (is_variant<T>) {
+        return std::visit([](const auto& x) { return rlp_serialize(x); }, val);
+    } else if constexpr (std::is_same_v<rlp_value, T>) {
+        // GCC 10 workaround; on gcc 11+/clang, the above case can deal with directly without first
+        // needing the static to the base std::variant type (aka rlp_variant).
+        return rlp_serialize(static_cast<const rlp_variant&>(val));
+    } else {
+        static_assert(std::is_void_v<T>, "Internal error: unhandled serializable type");
+    }
+}
+
+inline std::string rlp_serialize(const char* str) {
+    return rlp_serialize(std::string_view{str});
+}
+
+namespace detail {
+    inline std::string rlp_encode_payload(std::string_view payload, unsigned char base_code) {
+        std::string result;
+        if (payload.size() <= 55) {
+            result.reserve(1 + payload.size());
+            result.push_back(base_code + payload.size());
+        } else {
+
+            auto [buf, length] = rlp_encode_integer(payload.size());
+            result.reserve(1 + length.size() + payload.size());
+            result.push_back(base_code + 55 + length.size());
+            result += length;
+        }
+        result += payload;
+        return result;
+    }
+}  // namespace detail
+
+}  // namespace oxenc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SRC
     test_bt.cpp
     test_encoding.cpp
     test_endian.cpp
+    test_rlp.cpp
 )
 
 add_executable(tests ${TEST_SRC})
@@ -17,12 +18,6 @@ add_executable(tests ${TEST_SRC})
 find_package(Threads)
 
 target_link_libraries(tests Catch2::Catch2 oxenc)
-
-set_target_properties(tests PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-)
 
 add_custom_target(check COMMAND tests)
 

--- a/tests/test_bt.cpp
+++ b/tests/test_bt.cpp
@@ -499,7 +499,7 @@ TEST_CASE("Require integer/string methods", "[bt][dict][consumer][require]") {
 
     bt_dict_consumer btdp{data};
 
-    int a, c, i, k;
+    [[maybe_unused]] int a, c, i, k;
     std::string e, g;
     bt_dict bd;
 
@@ -629,12 +629,12 @@ TEST_CASE("bt append_signature", "[bt][signature]") {
 
     // Test with long keys for the sig field (figuring out the exact signing value is a little
     // complicated because of the integer in the key value; this is for testing that logic).
-    for (size_t len : {9, 10, 11, 99, 100, 101, 999, 1000, 9999, 10000}) {
+    for (auto len : {9, 10, 11, 99, 100, 101, 999, 1000, 9999, 10000}) {
         SECTION("sig key length " + std::to_string(len)) {
             bt_dict_producer dp2;
             dp2.append("a", 1);
-            std::string sig_key(len, 'x');
-            dp2.append_signature(sig_key, [](std::string_view to_sign) { return "sig"; });
+            std::string sig_key(static_cast<size_t>(len), 'x');
+            dp2.append_signature(sig_key, [](std::string_view) { return "sig"; });
             bt_dict_consumer dc2{dp2.view()};
             CHECK(dc2.next_integer<int>() == std::make_pair("a"sv, 1));
             auto [key, msg, sig] = dc2.next_signature();

--- a/tests/test_rlp.cpp
+++ b/tests/test_rlp.cpp
@@ -1,0 +1,134 @@
+
+#include <limits>
+#include <map>
+#include <set>
+
+#include "common.h"
+#include "oxenc/rlp_serialize.h"
+
+TEST_CASE("RLP serialization", "[rlp][serialization]") {
+    CHECK(oxenc::to_hex(rlp_serialize("dog")) == "83646f67");
+
+    std::vector<std::string> animals = {"cat", "dog"};
+    CHECK(oxenc::to_hex(rlp_serialize(animals)) == "c88363617483646f67");
+
+    CHECK(oxenc::to_hex(rlp_serialize("")) == "80");
+
+    CHECK(oxenc::to_hex(rlp_serialize(uint32_t{0})) == "80");
+    CHECK(oxenc::to_hex(rlp_serialize("\x0f"s)) == "0f");
+    CHECK(oxenc::to_hex(rlp_serialize("\x7f"s)) == "7f");
+    CHECK(oxenc::to_hex(rlp_serialize("\x04\x00"s)) == "820400");
+
+    using V = std::variant<unsigned, std::string, std::array<unsigned, 2>, std::vector<unsigned>>;
+    V v1 = unsigned{123};
+    V v2 = "hello"s;
+    V v3 = std::array{10u, 1000u};
+    CHECK(oxenc::to_hex(rlp_serialize(v1)) == "7b");
+    CHECK(oxenc::to_hex(rlp_serialize(v2)) == "8568656c6c6f");
+    CHECK(oxenc::to_hex(rlp_serialize(v3)) == "c40a8203e8");
+
+    std::vector<V> big_v;
+    CHECK(oxenc::to_hex(rlp_serialize(big_v)) == "c0");
+    big_v.emplace_back(unsigned{1234});
+    big_v.emplace_back(std::vector<unsigned>{1u, 2u, 3u});
+    big_v.emplace_back(std::vector<unsigned>{});
+    CHECK(oxenc::to_hex(rlp_serialize(big_v)) ==
+          "c8"
+          "8204d2"
+          "c3010203"
+          "c0");
+
+    big_v.emplace_back("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"s);
+    CHECK(oxenc::to_hex(rlp_serialize(big_v)) ==
+          "f7"
+          "8204d2"
+          "c3010203"
+          "c0"
+          "ae"
+          "4242424242424242424242424242424242424242424242424242424242424242424242424242424242424242"
+          "4242");
+
+    big_v.pop_back();
+    big_v.emplace_back("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"s);
+    CHECK(oxenc::to_hex(rlp_serialize(big_v)) ==
+          "f8"
+          "38"
+          "8204d2"
+          "c3010203"
+          "c0"
+          "af"
+          "4242424242424242424242424242424242424242424242424242424242424242424242424242424242424242"
+          "424242");
+
+    CHECK(oxenc::to_hex(rlp_serialize("Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                                      "Curabitur mauris magna, suscipit sed vehicula non, iaculis "
+                                      "faucibus tortor. Proin suscipit ultricies malesuada. Duis "
+                                      "tortor elit, dictum quis tristique eu, ultrices at risus. "
+                                      "Morbi a est imperdiet mi ullamcorper aliquet suscipit nec "
+                                      "lorem. Aenean quis leo mollis, vulputate elit varius, "
+                                      "consequat enim. Nulla ultrices turpis justo, et posuere "
+                                      "urna consectetur nec. Proin non convallis metus. Donec "
+                                      "tempor ipsum in mauris congue sollicitudin. Vestibulum ante "
+                                      "ipsum primis in faucibus orci luctus et ultrices posuere "
+                                      "cubilia Curae; Suspendisse convallis sem vel massa "
+                                      "faucibus, eget lacinia lacus tempor. Nulla quis ultricies "
+                                      "purus. Proin auctor rhoncus nibh condimentum mollis. "
+                                      "Aliquam consequat enim at metus luctus, a eleifend purus "
+                                      "egestas. Curabitur at nibh metus. Nam bibendum, neque at "
+                                      "auctor tristique, lorem libero aliquet arcu, non interdum "
+                                      "tellus lectus sit amet eros. Cras rhoncus, metus ac ornare "
+                                      "cursus, dolor justo ultrices metus, at ullamcorper "
+                                      "volutpat")) ==
+          "b904004c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061"
+          "646970697363696e6720656c69742e20437572616269747572206d6175726973206d61676e612c2073757363"
+          "6970697420736564207665686963756c61206e6f6e2c20696163756c697320666175636962757320746f7274"
+          "6f722e2050726f696e20737573636970697420756c74726963696573206d616c6573756164612e2044756973"
+          "20746f72746f7220656c69742c2064696374756d2071756973207472697374697175652065752c20756c7472"
+          "696365732061742072697375732e204d6f72626920612065737420696d70657264696574206d6920756c6c61"
+          "6d636f7270657220616c6971756574207375736369706974206e6563206c6f72656d2e2041656e65616e2071"
+          "756973206c656f206d6f6c6c69732c2076756c70757461746520656c6974207661726975732c20636f6e7365"
+          "7175617420656e696d2e204e756c6c6120756c74726963657320747572706973206a7573746f2c2065742070"
+          "6f73756572652075726e6120636f6e7365637465747572206e65632e2050726f696e206e6f6e20636f6e7661"
+          "6c6c6973206d657475732e20446f6e65632074656d706f7220697073756d20696e206d617572697320636f6e"
+          "67756520736f6c6c696369747564696e2e20566573746962756c756d20616e746520697073756d207072696d"
+          "697320696e206661756369627573206f726369206c756374757320657420756c74726963657320706f737565"
+          "726520637562696c69612043757261653b2053757370656e646973736520636f6e76616c6c69732073656d20"
+          "76656c206d617373612066617563696275732c2065676574206c6163696e6961206c616375732074656d706f"
+          "722e204e756c6c61207175697320756c747269636965732070757275732e2050726f696e20617563746f7220"
+          "72686f6e637573206e69626820636f6e64696d656e74756d206d6f6c6c69732e20416c697175616d20636f6e"
+          "73657175617420656e696d206174206d65747573206c75637475732c206120656c656966656e642070757275"
+          "7320656765737461732e20437572616269747572206174206e696268206d657475732e204e616d2062696265"
+          "6e64756d2c206e6571756520617420617563746f72207472697374697175652c206c6f72656d206c69626572"
+          "6f20616c697175657420617263752c206e6f6e20696e74657264756d2074656c6c7573206c65637475732073"
+          "697420616d65742065726f732e20437261732072686f6e6375732c206d65747573206163206f726e61726520"
+          "6375727375732c20646f6c6f72206a7573746f20756c747269636573206d657475732c20617420756c6c616d"
+          "636f7270657220766f6c7574706174");
+
+    CHECK(oxenc::to_hex(rlp_serialize(0u)) == "80");
+    CHECK(oxenc::to_hex(rlp_serialize(1u)) == "01");
+    CHECK(oxenc::to_hex(rlp_serialize(16u)) == "10");
+    CHECK(oxenc::to_hex(rlp_serialize(79u)) == "4f");
+    CHECK(oxenc::to_hex(rlp_serialize(127u)) == "7f");
+    CHECK(oxenc::to_hex(rlp_serialize(128u)) == "8180");
+    CHECK(oxenc::to_hex(rlp_serialize(1000u)) == "8203e8");
+    CHECK(oxenc::to_hex(rlp_serialize(100000u)) == "830186a0");
+
+    rlp_value twenty_three{23u};
+    CHECK(oxenc::to_hex(rlp_serialize(twenty_three)) == "17");
+
+    // [ [], [[]], [ [], [[]] ] ]
+    rlp_list x;
+    x.push_back(rlp_list{});
+    rlp_list y;
+    y.push_back(rlp_list{});
+    x.push_back(std::move(y));
+    y.clear();
+    y.push_back(rlp_list{});
+    rlp_list z;
+    z.push_back(rlp_list{});
+    y.push_back(std::move(z));
+    x.push_back(std::move(y));
+
+    CHECK(oxenc::to_hex(rlp_serialize(x)) == "c7c0c1c0c3c0c1c0");
+
+}


### PR DESCRIPTION
For ethyl, which currently depends on rlpvalue, but that is a nuissance to build and appears unmaintained.

Also drops the tests overriding (and downgrading) to C++17.