### PR TITLE
Allow consuming std::array's; allow other output types in consume

### DIFF
--- a/oxenc/bt_producer.h
+++ b/oxenc/bt_producer.h
@@ -11,12 +11,11 @@
 #include <unordered_map>
 #include <utility>
 
-#include "common.h"
-
 #ifndef NDEBUG
 #include "bt_serialize.h"
 #endif
 
+#include "common.h"
 #include "variant.h"
 
 namespace oxenc {
@@ -331,7 +330,7 @@ class bt_list_producer {
     }
 
     /// Appends elements from the range [from, to) to the list.  This does *not* append the elements
-    /// as a sublist: for that you should use something like: `l.append_list().append(from, to);`
+    /// as a sublist: for that you should use `append_list`
     template <typename ForwardIt>
     void append(ForwardIt from, ForwardIt to) {
         if (has_child)
@@ -339,6 +338,20 @@ class bt_list_producer {
         while (from != to)
             append_impl(*from++);
         append_intermediate_ends();
+    }
+
+    /// Appends an input list container as a sublist.  Equivalenet to append_list(tuple).  Note that
+    /// this is not equivalent to the iterator pair overload above: that appends to the current
+    /// list, while this one creates a new sublist and appends the container elements to that.
+    template <bt_input_list_container L>
+    void append(const L& list) {
+        append_list(list);
+    }
+
+    /// Appends a tuple/pair/array as a sublist.  Equivalent to append_list(tuple).
+    template <tuple_like Tuple>
+    void append(const Tuple& tuple) {
+        append_list(tuple);
     }
 
     /// Appends an optional value: the value will be appended as if by calling `.append(*val)` if
@@ -366,6 +379,21 @@ class bt_list_producer {
     /// outlive the parent.
     bt_list_producer append_list();
 
+    template <typename ForwardIt>
+    void append_list(ForwardIt from, ForwardIt to) {
+        append_list().append(from, to);
+    }
+
+    /// Appends a compatible input list container as a sublist
+    template <bt_input_list_container L>
+    void append_list(const L& input) {
+        append_list(input.begin(), input.end());
+    }
+
+    /// Appends a tuple/pair/array as a sublist
+    template <tuple_like Tuple>
+    void append_list(const Tuple& t);
+
     /// Appends a dict to this list.  Returns a new bt_dict_producer that references the parent
     /// list.  The parent cannot be added to until the subdict is destroyed.  This is meant to be
     /// used via RAII (see append_list() for details).
@@ -373,6 +401,12 @@ class bt_list_producer {
     /// If doing more complex lifetime management, take care not to allow the child instance to
     /// outlive the parent.
     bt_dict_producer append_dict();
+
+    /// There is no append_dict() taking a generic dict-like object because we can't ensure it
+    /// iterates in sorted order, and therefore we can't append it without copying into a sorted
+    /// container.
+    template <bt_input_dict_container D>
+    void append_dict(const D&) = delete;
 
     /// Appends a bt_value, bt_dict, or bt_list to this bt_list.  You must include the
     /// bt_value_producer.h header (either directly or via bt.h) to use this method.
@@ -513,6 +547,20 @@ class bt_dict_producer : bt_list_producer {
         append_intermediate_ends();
     }
 
+    /// Appends an input list container as a sublist.  Equivalenet to append_list(tuple).  Note that
+    /// this is not equivalent to the iterator pair overload above: that appends to the current
+    /// list, while this one creates a new sublist and appends the container elements to that.
+    template <bt_input_list_container L>
+    void append(std::string_view key, const L& list) {
+        append_list(key, list);
+    }
+
+    /// Appends a tuple/pair/array as a sublist.  Equivalent to append_list(tuple).
+    template <tuple_like Tuple>
+    void append(std::string_view key, const Tuple& tuple) {
+        append_list(key, tuple);
+    }
+
     /// Appends a key-value pair with an optional value, *if* the optional is set.  If the value is
     /// nullopt, nothing is appended.
     template <typename T>
@@ -594,6 +642,24 @@ class bt_dict_producer : bt_list_producer {
         append_impl(key);
         return bt_list_producer{this};
     }
+
+    /// Appends a list to this dict with the given key (which must be ascii-larger than the previous
+    /// key), and then appends the given iterator range to it.
+    template <typename ForwardIt>
+    void append_list(std::string_view key, ForwardIt from, ForwardIt to) {
+        append_list(key).append(from, to);
+    }
+
+    /// Appends a list to this dict with the given key (which must be ascii-larger than the previous
+    /// key), and then appends all the element of the given input list compatible container to it.
+    template <bt_input_list_container L>
+    void append_list(std::string_view key, const L& list) {
+        append_list(key, list.begin(), list.end());
+    }
+
+    /// Appends a tuple/pair/array as a sublist with the given key.
+    template <tuple_like Tuple>
+    void append_list(std::string_view key, const Tuple& tuple);
 
     /// Appends a bt_value, bt_dict, or bt_list to this bt_dict.  You must include the
     /// bt_value_producer.h header (either directly or via bt.h) to use this method.
@@ -738,6 +804,25 @@ inline bt_dict_producer bt_list_producer::append_dict() {
     if (has_child)
         throw std::logic_error{"Cannot call append_dict while another nested list/dict is active"};
     return bt_dict_producer{this};
+}
+
+namespace detail {
+
+    template <tuple_like Tuple, size_t... Is>
+    inline void append_tuple(bt_list_producer l, const Tuple& t, std::index_sequence<Is...>) {
+        (l.append(std::get<Is>(t)), ...);
+    }
+
+}  // namespace detail
+
+template <tuple_like Tuple>
+void bt_list_producer::append_list(const Tuple& t) {
+    detail::append_tuple(append_list(), t, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+}
+
+template <tuple_like Tuple>
+void bt_dict_producer::append_list(std::string_view key, const Tuple& t) {
+    detail::append_tuple(append_list(key), t, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
 }
 
 }  // namespace oxenc

--- a/oxenc/bt_serialize.h
+++ b/oxenc/bt_serialize.h
@@ -287,11 +287,14 @@ namespace detail {
         }
     };
 
+    template <typename Tuple>
+    concept tuple_like = requires { std::tuple_size<Tuple>::value; };
+
     /// Accept anything that looks iterable; value serialization validity isn't checked here (it
     /// fails via the base case static assert).
     template <typename T>
     concept bt_input_list_container =
-            !std::same_as<T, std::string> && !std::same_as<T, std::string_view> &&
+            !std::same_as<T, std::string> && !std::same_as<T, std::string_view> && !tuple_like<T> &&
             !bt_input_dict_container<T> && requires {
                 typename T::const_iterator;
                 typename T::value_type;
@@ -342,29 +345,29 @@ namespace detail {
         }
     };
 
-    /// Serializes a tuple or pair of serializable values (as a list on the wire)
+    /// Serializes a tuple, pair, or array of serializable values (as a list on the wire)
 
-    /// Common implementation for both tuple and pair:
-    template <template <typename...> typename Tuple, typename... T>
-    struct bt_serialize_tuple {
+    /// Common implementation for tuple/pair/array:
+    template <tuple_like Tuple>
+    struct bt_serialize<Tuple> {
       private:
         template <size_t... Is>
-        void operator()(std::ostream& os, const Tuple<T...>& elems, std::index_sequence<Is...>) {
+        void operator()(std::ostream& os, const Tuple& elems, std::index_sequence<Is...>) {
             os << 'l';
-            (bt_serialize<T>{}(os, std::get<Is>(elems)), ...);
+            (bt_serialize<std::tuple_element_t<Is, Tuple>>{}(os, std::get<Is>(elems)), ...);
             os << 'e';
         }
 
       public:
-        void operator()(std::ostream& os, const Tuple<T...>& elems) {
-            operator()(os, elems, std::index_sequence_for<T...>{});
+        void operator()(std::ostream& os, const Tuple& elems) {
+            operator()(os, elems, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
         }
     };
-    template <template <typename...> typename Tuple, typename... T>
-    struct bt_deserialize_tuple {
+    template <tuple_like Tuple>
+    struct bt_deserialize<Tuple> {
       private:
         template <size_t... Is>
-        void operator()(std::string_view& s, Tuple<T...>& elems, std::index_sequence<Is...>) {
+        void operator()(std::string_view& s, Tuple& elems, std::index_sequence<Is...>) {
             // Smallest list is 2 bytes "le", for an empty list.
             if (s.size() < 2)
                 throw bt_deserialize_invalid(
@@ -373,7 +376,7 @@ namespace detail {
                 throw bt_deserialize_invalid_type(
                         "Deserialization of tuple failed: expected 'l', found '"s + s[0] + "'"s);
             s.remove_prefix(1);
-            (bt_deserialize<T>{}(s, std::get<Is>(elems)), ...);
+            (bt_deserialize<std::tuple_element_t<Is, Tuple>>{}(s, std::get<Is>(elems)), ...);
             if (s.empty())
                 throw bt_deserialize_invalid(
                         "Deserialization failed: encountered end of string before tuple was "
@@ -385,30 +388,15 @@ namespace detail {
         }
 
       public:
-        void operator()(std::string_view& s, Tuple<T...>& elems) {
-            operator()(s, elems, std::index_sequence_for<T...>{});
+        void operator()(std::string_view& s, Tuple& elems) {
+            operator()(s, elems, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
         }
     };
-    template <typename... T>
-    struct bt_serialize<std::tuple<T...>> : bt_serialize_tuple<std::tuple, T...> {};
-    template <typename... T>
-    struct bt_deserialize<std::tuple<T...>> : bt_deserialize_tuple<std::tuple, T...> {};
-    template <typename S, typename T>
-    struct bt_serialize<std::pair<S, T>> : bt_serialize_tuple<std::pair, S, T> {};
-    template <typename S, typename T>
-    struct bt_deserialize<std::pair<S, T>> : bt_deserialize_tuple<std::pair, S, T> {};
-
-    template <typename T>
-    inline constexpr bool is_bt_tuple = false;
-    template <typename... T>
-    inline constexpr bool is_bt_tuple<std::tuple<T...>> = true;
-    template <typename S, typename T>
-    inline constexpr bool is_bt_tuple<std::pair<S, T>> = true;
 
     template <typename T>
     concept bt_deserializable =
             std::same_as<T, std::string> || std::integral<T> || bt_output_dict_container<T> ||
-            bt_output_list_container<T> || is_bt_tuple<T>;
+            bt_output_list_container<T> || tuple_like<T>;
 
     // General template and base case; this base will only actually be invoked when Ts... is empty,
     // which means we reached the end without finding any variant type capable of holding the value.
@@ -429,7 +417,7 @@ namespace detail {
     struct bt_deserialize_try_variant_impl<Variant, T, Ts...> {
         void operator()(std::string_view& s, Variant& variant) {
             if (bt_output_list_container<T>    ? s[0] == 'l'
-                : is_bt_tuple<T>               ? s[0] == 'l'
+                : tuple_like<T>                ? s[0] == 'l'
                 : bt_output_dict_container<T>  ? s[0] == 'd'
                 : std::integral<T>             ? s[0] == 'i'
                 : std::same_as<T, std::string> ? s[0] >= '0' && s[0] <= '9'
@@ -629,21 +617,21 @@ IntType get_int(const bt_value& v) {
 }
 
 namespace detail {
-    template <typename Tuple, size_t... Is>
+    template <tuple_like Tuple, size_t... Is>
     void get_tuple_impl(Tuple& t, const bt_list& l, std::index_sequence<Is...>);
 }
 
-/// Converts a bt_list into the given template std::tuple or std::pair.  Throws a
+/// Converts a bt_list into the given template std::tuple, std::pair, or std::array.  Throws a
 /// std::invalid_argument if the list has the wrong size or wrong element types.  Supports recursion
 /// (i.e. if the tuple itself contains tuples or pairs).  The tuple (or nested tuples) may only
 /// contain integral types, strings, string_views, bt_list, bt_dict, and tuples/pairs of those.
-template <typename Tuple>
+template <detail::tuple_like Tuple>
 Tuple get_tuple(const bt_list& x) {
     Tuple t;
     detail::get_tuple_impl(t, x, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
     return t;
 }
-template <typename Tuple>
+template <detail::tuple_like Tuple>
 Tuple get_tuple(const bt_value& x) {
     return get_tuple<Tuple>(var::get<bt_list>(static_cast<const bt_variant&>(x)));
 }
@@ -657,7 +645,7 @@ namespace detail {
         const bt_variant& v = *it++;
         if constexpr (std::integral<T>) {
             t = oxenc::get_int<T>(v);
-        } else if constexpr (is_bt_tuple<T>) {
+        } else if constexpr (tuple_like<T>) {
             if (std::holds_alternative<bt_list>(v))
                 throw std::invalid_argument{
                         "Unable to convert tuple: cannot create sub-tuple from non-bt_list"};
@@ -673,7 +661,7 @@ namespace detail {
             t = var::get<T>(v);
         }
     }
-    template <typename Tuple, size_t... Is>
+    template <tuple_like Tuple, size_t... Is>
     void get_tuple_impl(Tuple& t, const bt_list& l, std::index_sequence<Is...>) {
         if (l.size() != sizeof...(Is))
             throw std::invalid_argument{"Unable to convert tuple: bt_list has wrong size"};
@@ -687,10 +675,10 @@ namespace detail {
             return c.template consume_integer<T>();
         else if constexpr (detail::is_string_like<T>)
             return T{c.template consume_string_view<typename T::value_type>()};
-        else if constexpr (std::same_as<T, bt_dict>)
-            return c.consume_dict();
-        else if constexpr (std::same_as<T, bt_list>)
-            return c.consume_list();
+        else if constexpr (std::same_as<T, bt_list> || tuple_like<T> || bt_output_list_container<T>)
+            return c.template consume_list<T>();
+        else if constexpr (std::same_as<T, bt_dict> || bt_output_dict_container<T>)
+            return c.template consume_dict<T>();
         else if constexpr (std::same_as<T, bt_dict_consumer>)
             return c.consume_dict_consumer();
         else {

--- a/oxenc/common.h
+++ b/oxenc/common.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <concepts>
 #include <iterator>
+#include <string>
 #include <string_view>
 #include <type_traits>
 
@@ -14,6 +15,39 @@ concept string_view_compatible = std::convertible_to<T, std::string_view> ||
 template <typename Char>
 concept basic_char = sizeof(Char) == 1 && !std::same_as<Char, bool> &&
                      (std::integral<Char> || std::same_as<Char, std::byte>);
+
+/// Partial dict validity; we don't check the second type for serializability, that will be
+/// handled via the base case static_assert if invalid.
+template <typename T>
+concept bt_input_dict_container =
+        (std::same_as<std::string, std::remove_cv_t<typename T::value_type::first_type>> ||
+         std::same_as<
+                 std::string_view,
+                 std::remove_cv_t<typename T::value_type::first_type>>)&&requires {
+            typename T::const_iterator;           // is const iterable
+            typename T::value_type::second_type;  // has a second type
+        };
+
+template <typename Tuple>
+concept tuple_like = requires { std::tuple_size<Tuple>::value; };
+
+// True if the type is a std::string, std::string_view, or some a basic_string<Char> for some
+// single-byte type Char.
+template <typename T>
+constexpr bool is_string_like = false;
+template <typename Char>
+inline constexpr bool is_string_like<std::basic_string<Char>> = sizeof(Char) == 1;
+template <typename Char>
+inline constexpr bool is_string_like<std::basic_string_view<Char>> = sizeof(Char) == 1;
+
+/// Accept anything that looks iterable (except for string-like types); value serialization
+/// validity isn't checked here (it fails via the base case static assert).
+template <typename T>
+concept bt_input_list_container =
+        !is_string_like<T> && !tuple_like<T> && !bt_input_dict_container<T> && requires {
+            typename T::const_iterator;
+            typename T::value_type;
+        };
 
 using namespace std::literals;
 

--- a/tests/test_bt.cpp
+++ b/tests/test_bt.cpp
@@ -276,7 +276,7 @@ TEST_CASE("bt streaming list producer", "[bt][list][producer]") {
     lp += 42;
     CHECK(lp.view() == "l3:abci42ee");
     std::vector<int> randos = {{1, 17, -999}};
-    lp.append(randos.begin(), randos.end());
+    lp.extend(randos.begin(), randos.end());
     CHECK(lp.view() == "l3:abci42ei1ei17ei-999ee");
 
     {
@@ -374,7 +374,7 @@ TEST_CASE("bt streaming dict producer", "[bt][dict][producer]") {
     CHECK(dp.view() == "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:i1eee"sv);
 
     std::map<std::string, int> to_append{{"q", 1}, {"r", 2}, {"~", 3}, {"~1", 4}};
-    dp.append(to_append.begin(), to_append.end());
+    dp.extend(to_append.begin(), to_append.end());
 
     CHECK(dp.view() ==
           "d3:foo3:bar4:foo\0i-333222111e6:myListl0:i2ei42ee1:pd0:i1ee1:qi1e1:ri2e1:~i3e2:~1i4ee"sv);


### PR DESCRIPTION
This rewrites the tuple/pair code a bit so that it is also usable for std::array so that things like:

    auto arr = btdp.consume_list<std::array<int, 3>>("v");

now works.  Previously we could consume to a tuple, pair, or expandable container like a vector, but not to an std::array.  Now we can.

It also enlarges the recognized things in `consume` to allow any arbitrary deserializable list/dict types (including tuple, and now array).  You could get previously get them via `consume_list<mytype>()`, but `consume<mytype>()` didn't accept/recognize it as a list type: now it does, and similarly for dict-like types.  (This also implicitly extends to `require<T>`).

Edit: added a second commit that does a similar thing with `append()` for producers.